### PR TITLE
Remove Codecov badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/bdperkin/nhl-scrabble/actions/workflows/ci.yml/badge.svg)](https://github.com/bdperkin/nhl-scrabble/actions/workflows/ci.yml)
 [![Python 3.10-3.13](https://img.shields.io/badge/python-3.10--3.13-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![codecov](https://codecov.io/gh/bdperkin/nhl-scrabble/branch/main/graph/badge.svg)](https://codecov.io/gh/bdperkin/nhl-scrabble)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![Type checked: mypy](https://img.shields.io/badge/type%20checked-mypy-blue.svg)](http://mypy-lang.org/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)


### PR DESCRIPTION
## Summary

Remove the Codecov badge from README.md since Codecov integration is not currently configured for this project.

## Problem

The Codecov badge was added in PR #2 but Codecov is not actually set up for this repository. Without proper Codecov configuration and integration, the badge:
- Does not display correctly
- Links to a non-existent Codecov project page
- May confuse users looking for coverage metrics

## Solution

Remove the Codecov badge until/if Codecov integration is properly set up in the future.

## Changes

- Removed line 6 from README.md containing the Codecov badge
- No other changes to the README

## Badges Remaining (10 total)

**Build & Quality:**
- ✅ CI Status (GitHub Actions)
- ✅ Code style: Ruff
- ✅ Type checked: MyPy
- ✅ Pre-commit enabled
- ✅ Powered by UV

**Project Info:**
- ✅ Python 3.10-3.13
- ✅ License: MIT

**GitHub Stats:**
- ✅ GitHub stars
- ✅ GitHub issues
- ✅ GitHub last commit

## Future Consideration

If Codecov is configured in the future, the badge can easily be re-added:
```markdown
[![codecov](https://codecov.io/gh/bdperkin/nhl-scrabble/branch/main/graph/badge.svg)](https://codecov.io/gh/bdperkin/nhl-scrabble)
```

## Testing

- [x] Pre-commit hooks pass
- [x] README displays correctly with 10 badges
- [x] No broken links