### PR TITLE
Configure comprehensive and strict mypy type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.20.1
     hooks:
       - id: mypy
         additional_dependencies: [types-requests, pydantic]
-        args: [--strict, --ignore-missing-imports]
+        args: []  # Config is in pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,20 +209,65 @@ docstring-code-format = true
 # MyPy configuration
 [tool.mypy]
 python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-no_implicit_optional = true
-warn_redundant_casts = true
+
+# Enable strict mode (equivalent to all strict flags)
+strict = true
+
+# Additional strict options beyond basic strict mode
+warn_unreachable = true
+warn_no_return = true
+disallow_any_unimported = false  # Too strict for third-party libs
+disallow_any_expr = false  # Too strict for practical use
+disallow_any_decorated = false  # Too strict for decorators
+disallow_any_explicit = false  # Too strict for practical use
+disallow_any_generics = true
+disallow_subclassing_any = true
+
+# Additional warnings
 warn_unused_ignores = true
+warn_return_any = true
+warn_redundant_casts = true
+warn_unused_configs = true
+
+# Strict optional handling
+strict_optional = true
 strict_equality = true
+strict_concatenate = true
+
+# Error reporting
+show_error_context = true
+show_column_numbers = true
+show_error_code_links = true
+pretty = true
+color_output = true
+error_summary = true
+show_absolute_path = false
+
+# Import discovery
+namespace_packages = true
+explicit_package_bases = false  # Avoid duplicate module detection
+ignore_missing_imports = true  # Practical for third-party libs without stubs
+mypy_path = "src"
+
+# Miscellaneous
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+no_implicit_reexport = true
 
 [[tool.mypy.overrides]]
-module = ["tests.*", "conftest", "nhl_scrabble.cli"]
+module = ["tests.*", "conftest"]
 disallow_untyped_defs = false
 disallow_untyped_decorators = false
+warn_return_any = false
+check_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["nhl_scrabble.cli"]
+disallow_untyped_defs = false
+disallow_untyped_decorators = false
+warn_return_any = false
 
 # Pytest configuration
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Implements comprehensive and strict mypy type checking with strict mode enabled and additional strict options for maximum type safety.

## Changes

### Configuration
- **pyproject.toml**: 
  - Enable mypy `strict = true` mode (equivalent to all strict flags)
  - Add comprehensive strict options beyond basic strict mode:
    - `warn_unreachable`, `warn_no_return` - Detect unreachable code
    - `disallow_any_generics`, `disallow_subclassing_any` - Restrict Any types
    - `strict_optional`, `strict_equality`, `strict_concatenate` - Strict type handling
    - `no_implicit_reexport` - Prevent implicit re-exports
  - Configure detailed error reporting:
    - `show_error_context`, `show_column_numbers`, `show_error_code_links`
    - `pretty`, `color_output`, `error_summary`
  - Set import discovery: `namespace_packages`, `mypy_path = "src"`
  - Keep `ignore_missing_imports = true` for practical third-party lib handling
  - Update mypy overrides: separate tests and CLI configurations
  - Disable overly strict options: `disallow_any_unimported`, `disallow_any_expr`, `disallow_any_decorated`, `disallow_any_explicit`

- **.pre-commit-config.yaml**: 
  - Update mypy version from v1.8.0 to v1.20.1
  - Remove CLI args (config now centralized in pyproject.toml)

### Type Support
- **src/nhl_scrabble/py.typed**: 
  - Add PEP 561 marker file for typed package compliance
  - Enables type checkers to use type information from this package

## Testing

All three required testing methods passed:

✅ **Pre-commit**: `pre-commit run --all-files`  
✅ **Tox**: `tox -e mypy`  
✅ **Make**: `make mypy`

All tests show: **Success: no issues found in 23 source files**

## Impact

- Stricter type checking enforcement across the project
- Consistent mypy configuration across pre-commit, tox, make, and GitHub CI
- Updated mypy version (v1.8.0 → v1.20.1) ensures latest features
- PEP 561 compliance allows type checkers to use package type hints
- Better error reporting with context, colors, and links

## Notes

- Configuration is comprehensive but reasonable (disables overly strict Any checks)
- `ignore_missing_imports = true` is practical for third-party libs without stubs
- Tests and CLI modules have relaxed type checking (as appropriate)
- The py.typed file will be included in distribution packages

## Related Issues

N/A