### PR TITLE
Add pygrep-hooks for Python-specific code quality checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,20 @@ repos:
       # Executable checks
       - id: check-shebang-scripts-are-executable
 
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      # Python code quality checks
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+      - id: python-check-mock-methods
+      - id: python-no-eval
+      - id: python-no-log-warn
+      - id: python-use-type-annotations
+
+      # Text content checks
+      - id: text-unicode-replacement-char
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:


### PR DESCRIPTION
## Summary

Adds 7 hooks from the `pygrep-hooks` repository for Python-specific grep-based code quality and best practice enforcement.

## New Hooks Added

### Python Code Quality Checks (6 hooks)

**python-check-blanket-noqa**
- Enforces that `# noqa` annotations always occur with specific codes
- Example: `# noqa: F401` ✅ vs `# noqa` ❌
- **Benefits**: Improves code clarity and makes it explicit which rule is being suppressed
- Currently not used in codebase, but enforces best practice for future use

**python-check-blanket-type-ignore**
- Enforces that `# type: ignore` annotations always occur with specific codes
- Example: `# type: ignore[no-any-return]` ✅ vs `# type: ignore` ❌
- **Benefits**: Makes type ignores explicit and reviewable
- **Already following**: Codebase already uses specific codes (see `nhl_client.py`, `stats_report.py`)
- **Now enforced**: Prevents regression to blanket ignores

**python-check-mock-methods**
- Prevents common mistakes when using `unittest.mock`
- **Catches**:
  - `mock.assert_called` → should use `assert_called_with()`
  - `mock.assert_called_once` → should use `assert_called_once_with()`
  - `mock.assert_not_called` → should use `assert_not_called()`
- **Benefits**: Prevents silent test failures from typos
- **Relevant**: Tests use `Mock` from `unittest.mock`

**python-no-eval**
- Detects and prevents use of `eval()`
- **Security**: Prevents arbitrary code execution vulnerabilities
- **Best practice**: `eval()` is almost always the wrong choice
- Currently not used in codebase (good!)

**python-no-log-warn**
- Enforces use of `logging.warning()` instead of deprecated `logging.warn()`
- **Deprecated**: `logging.warn()` has been deprecated since Python 3.3
- **Best practice**: Maintains modern logging standards
- Currently not used in codebase (good!)

**python-use-type-annotations**
- Enforces use of PEP 484 type annotations instead of type comments
- Modern: `def func(x: int) -> str:` ✅
- Deprecated: `# type: (int) -> str` ❌
- **Already following**: Project uses type annotations throughout
- **Now enforced**: Prevents regression to old-style type comments

### Text Content Checks (1 hook)

**text-unicode-replacement-char**
- Forbids files containing the UTF-8 Unicode replacement character (U+FFFD)
- **Indicates**: Encoding issues or corrupted text
- **Benefits**: Prevents subtle bugs from invalid characters
- **Demonstrated value**: Caught invalid character during initial commit attempt! ✅

## Testing

All hooks tested and verified:

✅ **Pre-commit**: `pre-commit run --all-files` (all 30 hooks pass)  
✅ **python-check-blanket-noqa**: Passed  
✅ **python-check-blanket-type-ignore**: Passed  
✅ **python-check-mock-methods**: Passed  
✅ **python-no-eval**: Passed  
✅ **python-no-log-warn**: Passed  
✅ **python-use-type-annotations**: Passed  
✅ **text-unicode-replacement-char**: Passed (after fixing commit message!)  
✅ **check-hooks-apply**: Passed (validates all hooks apply)  

## Immediate Value

The `text-unicode-replacement-char` hook already demonstrated its value by catching an invalid Unicode character in the initial commit message attempt, preventing it from entering the repository.

## Impact

### Code Quality
- Enforces explicit noqa and type: ignore annotations
- Prevents mock testing mistakes
- Maintains modern Python practices (annotations, logging)

### Security
- Prevents eval() usage
- Reduces attack surface

### Repository Health
- Prevents encoding corruption
- Ensures cross-platform compatibility
- Maintains consistency with existing patterns

## Hook Count Summary

- **Before**: 23 hooks (2 meta + 18 pre-commit-hooks + 2 ruff + 1 mypy)
- **After**: 30 hooks (2 meta + 18 pre-commit-hooks + 7 pygrep-hooks + 2 ruff + 1 mypy)
- **New hooks**: 7 pygrep-hooks

## Related Issues

N/A