### PR TITLE
Update ruff hook from legacy 'ruff' to 'ruff-check'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 


### PR DESCRIPTION
## Summary

Updates the ruff-pre-commit hook from the legacy `ruff` hook ID to the new `ruff-check` hook ID, which is the current recommended approach from astral-sh.

## Changes

### Hook ID Update
**Before:**
```yaml
- id: ruff
  args: [--fix, --exit-non-zero-on-fix]
```

**After:**
```yaml
- id: ruff-check
  args: [--fix, --exit-non-zero-on-fix]
```

### What Changed
- **Hook ID**: `ruff` → `ruff-check`
- **Arguments**: Unchanged (`--fix`, `--exit-non-zero-on-fix`)
- **Behavior**: Identical linting functionality

## Background

### Ruff Hook Evolution

The ruff-pre-commit repository has evolved its hook naming:

1. **Legacy hook** (`ruff`):
   - Original hook ID for linting
   - Now marked as legacy/deprecated
   - Still works but not recommended for new configurations

2. **Current hooks**:
   - `ruff-check`: Linting (replaces legacy `ruff`)
   - `ruff-format`: Formatting (unchanged)

### Why This Matters

- **Clarity**: `ruff-check` is more explicit about what the hook does (checking/linting)
- **Future-proofing**: Aligns with current astral-sh recommendations
- **Best practices**: Uses the current, non-legacy hook ID
- **Separation of concerns**: Clear distinction between checking (ruff-check) and formatting (ruff-format)

## Benefits

### Immediate
- ✅ Uses current, recommended hook ID
- ✅ More descriptive hook name in pre-commit output
- ✅ Follows ruff-pre-commit best practices

### Long-term
- ✅ Future-proofs configuration
- ✅ Reduces technical debt
- ✅ Easier for new contributors to understand
- ✅ Aligned with ruff ecosystem evolution

## Testing

All hooks tested and verified:

✅ **ruff-check**: `pre-commit run ruff-check --all-files` → Passed  
✅ **All hooks**: `pre-commit run --all-files` → All 31 hooks pass  
✅ **Behavior**: Identical linting results to legacy `ruff` hook  
✅ **No regressions**: All code quality checks continue to pass  

## Pre-commit Output

**Before (legacy):**
```
ruff (legacy alias)......................................................Passed
```

**After (current):**
```
ruff check...............................................................Passed
```

The new output is clearer about what the hook does.

## Impact

### No Breaking Changes
- Same linting behavior
- Same arguments
- Same error detection
- Same auto-fixing capability

### Configuration Improvement
- Modern hook ID
- Better aligned with ruff ecosystem
- More maintainable going forward

## Migration Notes

This is a simple rename with no behavioral changes. The migration is:
- **Safe**: No functional changes to linting
- **Recommended**: Follows current astral-sh guidelines
- **Transparent**: Users won't notice any difference in behavior

## Related

- **ruff-format hook**: Unchanged (already uses current hook ID)
- **ruff version**: Unchanged (v0.15.10)
- **Hook count**: Unchanged (31 total)

## Related Issues

N/A