### PR TITLE
Add codespell for comprehensive spell checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: [py310, py311, py312, py313, ruff-check, mypy, coverage]
+        tox-env: [py310, py311, py312, py313, ruff-check, mypy, coverage, codespell]
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,12 @@ repos:
       # Text content checks
       - id: text-unicode-replacement-char
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.0
+    hooks:
+      - id: codespell
+        args: []  # Config is in pyproject.toml
+
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.5.18
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Comprehensive pre-commit hooks (32 total):
+- **Codespell Integration** - Spell checking for code and documentation
+  - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
+  - Pre-commit hook for automated spell checking
+  - Tox environment (codespell) for standalone spell checking
+  - Added to CI/CD pipeline for continuous spell checking
+  - Configured with check-filenames and check-hidden enabled by default
+  - Selective ignores for generated files and lock files
+- Comprehensive pre-commit hooks (33 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
+  - Spelling hooks (1): codespell for code and documentation spell checking
   - UV hook (1): uv-lock for dependency lock file validation
   - Ruff hooks (2): ruff-check (linting), ruff-format (formatting)
   - MyPy hook (1): strict type checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 32 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 33 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -110,9 +110,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (32 Comprehensive Checks)
+## Pre-commit Hooks (33 Comprehensive Checks)
 
-The project uses 32 pre-commit hooks for automatic code quality validation:
+The project uses 33 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -137,6 +137,9 @@ The project uses 32 pre-commit hooks for automatic code quality validation:
 - `python-no-log-warn`: Enforce logging.warning() vs deprecated logging.warn()
 - `python-use-type-annotations`: Enforce PEP 484 annotations vs type comments
 - `text-unicode-replacement-char`: Detect Unicode replacement character (U+FFFD)
+
+**Spelling Hooks (1 from codespell):**
+- `codespell`: Spell checking for code and documentation (comprehensive by default)
 
 **UV Hook (1 from uv-pre-commit):**
 - `uv-lock`: Maintains uv.lock file consistency with pyproject.toml
@@ -707,7 +710,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 32 hooks (meta, file quality, Python quality, UV, ruff, mypy)
+- **Pre-commit Hooks:** 33 hooks (meta, file quality, Python quality, spelling, UV, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (32 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (33 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -349,6 +349,7 @@ pre-commit autoupdate
 - **Meta hooks** (3): Configuration validation (check-hooks-apply, check-useless-excludes, sync-pre-commit-deps)
 - **File quality** (18): Formatting, syntax, security (trailing-whitespace, check-yaml, detect-private-key, etc.)
 - **Python quality** (7): Code patterns (blanket-noqa, mock-methods, eval, type-annotations, etc.)
+- **Spelling** (1): Code and documentation spell checking (codespell)
 - **UV** (1): Dependency lock file validation (uv-lock)
 - **Ruff** (2): Comprehensive linting and formatting (ruff-check, ruff-format)
 - **MyPy** (1): Strict type checking
@@ -510,7 +511,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 32 hooks (meta, pre-commit-hooks, pygrep-hooks, uv, ruff, mypy)
+- **Pre-commit Hooks**: 33 hooks (meta, pre-commit-hooks, pygrep-hooks, codespell, uv, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,7 +326,7 @@ skip = '*.lock,*.json,*.min.js,htmlcov/*,.git/*,.tox/*,.venv/*,*.egg-info/*,buil
 
 # Project-specific ignore words (like ruff's ignore list)
 # Add false positives here as they are discovered
-ignore-words-list = ''
+# ignore-words-list = 'word1,word2'  # Uncomment and add words when needed
 
 # Consistency settings
 count = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,23 @@ skip_covered = false
 [tool.coverage.html]
 directory = "htmlcov"
 
+# Codespell configuration
+[tool.codespell]
+# Comprehensive by default (matches ruff's ALL rules philosophy)
+check-filenames = true
+check-hidden = true
+
+# Skip patterns for non-text files and generated content
+skip = '*.lock,*.json,*.min.js,htmlcov/*,.git/*,.tox/*,.venv/*,*.egg-info/*,build/*,dist/*,.pytest_cache/*,.mypy_cache/*,.ruff_cache/*'
+
+# Project-specific ignore words (like ruff's ignore list)
+# Add false positives here as they are discovered
+ignore-words-list = ''
+
+# Consistency settings
+count = true
+quiet-level = 0  # Show all issues (comprehensive)
+
 # UV configuration
 [tool.uv]
 # Managed by uv for faster dependency resolution

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     ruff-format
     coverage
     pip-audit
+    codespell
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -124,6 +125,17 @@ commands_pre =
 commands =
     pip-audit {posargs}
 
+[testenv:codespell]
+# Spell checking - check code and documentation
+description = Check spelling in code and documentation
+labels = quality
+skip_install = true
+deps = codespell
+commands_pre =
+    codespell --version
+commands =
+    codespell {posargs:src tests docs *.md}
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -202,17 +214,20 @@ extras =
     lint
     type
     security
+deps = codespell
 commands_pre =
     ruff --version
     mypy --version
     pytest --version
     pip-audit --version
+    codespell --version
 commands =
     ruff format --check src tests
     ruff check src tests
     mypy src
     pytest --cov=nhl_scrabble --cov-report=term-missing --cov-fail-under=49
     pip-audit
+    codespell src tests docs *.md
 
 # Fast test environment (no coverage)
 [testenv:fast]


### PR DESCRIPTION
## Summary
- Implements codespell with configuration matching ruff's ALL rules philosophy
- Pre-commit hook for automated spell checking
- Tox environment (codespell) for standalone testing
- CI/CD integration via GitHub Actions

## Configuration
- Comprehensive configuration in pyproject.toml
- check-filenames and check-hidden enabled by default
- Selective ignores for generated files and lock files
- Integrated with pre-commit, tox, make, and GitHub CI

## Documentation
- Updated README.md with hook count (32 → 33)
- Updated CLAUDE.md with codespell section
- Updated CHANGELOG.md with detailed changes

## Testing
All three testing methods passed:
- ✅ `pre-commit run codespell --all-files`
- ✅ `tox -e codespell`
- ✅ `make tox-codespell`

## Test plan
- [x] Pre-commit hooks pass
- [x] Tox environment works
- [x] Makefile target works
- [x] Documentation updated
- [ ] CI/CD pipeline passes