### PR TITLE
Add validate-pyproject for comprehensive pyproject.toml validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: [py310, py311, py312, py313, ruff-check, mypy, coverage, codespell, pymarkdown]
+        tox-env: [py310, py311, py312, py313, ruff-check, mypy, coverage, codespell, pymarkdown, validate-pyproject]
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,13 @@ repos:
       # Text content checks
       - id: text-unicode-replacement-char
 
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.23
+    hooks:
+      - id: validate-pyproject
+        # Comprehensive validation (matches ruff's ALL rules philosophy)
+        args: []  # Config is in pyproject.toml
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Validate-pyproject Integration** - pyproject.toml validation against PEP standards
+  - Comprehensive validation matching ruff's ALL rules philosophy
+  - Pre-commit hook for automated pyproject.toml validation
+  - Tox environment (validate-pyproject) for standalone validation
+  - Added to CI/CD pipeline for continuous project metadata validation
+  - Validates against PEP 517 (build system), PEP 518 (build requirements), PEP 621 (project metadata), PEP 631 (dependencies)
+  - All validations enabled by default, ensuring complete PEP compliance
 - **PyMarkdown Integration** - Markdown linting and formatting
   - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
   - Pre-commit hook for automated markdown linting
@@ -23,10 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to CI/CD pipeline for continuous spell checking
   - Configured with check-filenames and check-hidden enabled by default
   - Selective ignores for generated files and lock files
-- Comprehensive pre-commit hooks (34 total):
+- Comprehensive pre-commit hooks (35 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
+  - Project validation hooks (1): validate-pyproject for pyproject.toml validation
   - Spelling hooks (1): codespell for code and documentation spell checking
   - Markdown hooks (1): pymarkdown for markdown linting and formatting
   - UV hook (1): uv-lock for dependency lock file validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 34 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 35 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -110,9 +110,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (34 Comprehensive Checks)
+## Pre-commit Hooks (35 Comprehensive Checks)
 
-The project uses 34 pre-commit hooks for automatic code quality validation:
+The project uses 35 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -137,6 +137,9 @@ The project uses 34 pre-commit hooks for automatic code quality validation:
 - `python-no-log-warn`: Enforce logging.warning() vs deprecated logging.warn()
 - `python-use-type-annotations`: Enforce PEP 484 annotations vs type comments
 - `text-unicode-replacement-char`: Detect Unicode replacement character (U+FFFD)
+
+**Project Validation Hooks (1 from validate-pyproject):**
+- `validate-pyproject`: Validates pyproject.toml against PEP 517, 518, 621, 631 standards
 
 **Spelling Hooks (1 from codespell):**
 - `codespell`: Spell checking for code and documentation (comprehensive by default)
@@ -713,7 +716,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 34 hooks (meta, file quality, Python quality, spelling, markdown, UV, ruff, mypy)
+- **Pre-commit Hooks:** 35 hooks (meta, file quality, Python quality, project validation, spelling, markdown, UV, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (34 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (35 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -349,6 +349,7 @@ pre-commit autoupdate
 - **Meta hooks** (3): Configuration validation (check-hooks-apply, check-useless-excludes, sync-pre-commit-deps)
 - **File quality** (18): Formatting, syntax, security (trailing-whitespace, check-yaml, detect-private-key, etc.)
 - **Python quality** (7): Code patterns (blanket-noqa, mock-methods, eval, type-annotations, etc.)
+- **Project validation** (1): pyproject.toml validation against PEP standards (validate-pyproject)
 - **Spelling** (1): Code and documentation spell checking (codespell)
 - **Markdown** (1): Markdown linting and formatting (pymarkdown)
 - **UV** (1): Dependency lock file validation (uv-lock)
@@ -512,7 +513,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 34 hooks (meta, pre-commit-hooks, pygrep-hooks, codespell, pymarkdown, uv, ruff, mypy)
+- **Pre-commit Hooks**: 35 hooks (meta, pre-commit-hooks, pygrep-hooks, validate-pyproject, codespell, pymarkdown, uv, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,16 @@ skip = '*.lock,*.json,*.min.js,htmlcov/*,.git/*,.tox/*,.venv/*,*.egg-info/*,buil
 count = true
 quiet-level = 0  # Show all issues (comprehensive)
 
+# Validate-pyproject configuration
+# Note: validate-pyproject validates this file (pyproject.toml) against PEP standards
+# It doesn't have configuration options itself - it validates the project metadata
+# Comprehensive validation (matches ruff's ALL rules philosophy):
+# - PEP 517: Build system declaration
+# - PEP 518: Specifying build system requirements
+# - PEP 621: Project metadata in pyproject.toml
+# - PEP 631: Dependency specification
+# All validations are enabled by default, ensuring complete compliance
+
 # PyMarkdown configuration
 [tool.pymarkdown]
 # Comprehensive by default (matches ruff's ALL rules philosophy)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     pip-audit
     codespell
     pymarkdown
+    validate-pyproject
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -148,6 +149,17 @@ commands_pre =
 commands =
     pymarkdown scan {posargs:*.md docs}
 
+[testenv:validate-pyproject]
+# Validate pyproject.toml - check project metadata and configuration
+description = Validate pyproject.toml against PEP standards
+labels = quality
+skip_install = true
+deps = validate-pyproject[all]
+commands_pre =
+    validate-pyproject --version
+commands =
+    validate-pyproject {posargs:pyproject.toml}
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -229,6 +241,7 @@ extras =
 deps =
     codespell
     pymarkdownlnt
+    validate-pyproject[all]
 commands_pre =
     ruff --version
     mypy --version
@@ -236,6 +249,7 @@ commands_pre =
     pip-audit --version
     codespell --version
     pymarkdown version
+    validate-pyproject --version
 commands =
     ruff format --check src tests
     ruff check src tests
@@ -244,6 +258,7 @@ commands =
     pip-audit
     codespell src tests docs *.md
     pymarkdown scan *.md docs
+    validate-pyproject pyproject.toml
 
 # Fast test environment (no coverage)
 [testenv:fast]


### PR DESCRIPTION
## Summary
- Implements validate-pyproject with configuration matching ruff's ALL rules philosophy
- Pre-commit hook for automated pyproject.toml validation
- Tox environment (validate-pyproject) for standalone testing
- CI/CD integration via GitHub Actions

## Configuration
- Validates pyproject.toml against multiple PEP standards:
  - PEP 517: Build system declaration
  - PEP 518: Specifying build system requirements
  - PEP 621: Storing project metadata in pyproject.toml
  - PEP 631: Dependency specification for Python Software Packages
- All validations enabled by default (comprehensive approach)
- No configuration needed - validate-pyproject validates the configuration file itself
- Integrated with pre-commit, tox, make, and GitHub CI

## Tool Details
- Package name: `validate-pyproject[all]` (includes all plugin validators)
- Pre-commit repo: https://github.com/abravalheri/validate-pyproject
- Ensures pyproject.toml is always compliant with Python packaging standards

## Documentation
- Updated README.md with hook count (34 → 35)
- Updated CLAUDE.md with validate-pyproject section
- Updated CHANGELOG.md with detailed changes
- Added configuration notes in pyproject.toml explaining validation scope

## Testing
All three testing methods passed:
- ✅ `pre-commit run validate-pyproject --all-files`
- ✅ `tox -e validate-pyproject`
- ✅ `make tox-validate-pyproject`

## Test plan
- [x] Pre-commit hooks pass
- [x] Tox environment works
- [x] Makefile target works
- [x] Documentation updated
- [x] Validates current pyproject.toml successfully
- [ ] CI/CD pipeline passes