### PR TITLE
Add yamllint for comprehensive YAML file validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: [py310, py311, py312, py313, ruff-check, mypy, coverage, codespell, pymarkdown, validate-pyproject]
+        tox-env:
+          - py310
+          - py311
+          - py312
+          - py313
+          - ruff-check
+          - mypy
+          - coverage
+          - codespell
+          - pymarkdown
+          - validate-pyproject
+          - yamllint
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,13 @@ repos:
         # Comprehensive validation (matches ruff's ALL rules philosophy)
         args: []  # Config is in pyproject.toml
 
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        # Comprehensive YAML linting (matches ruff's ALL rules philosophy)
+        args: []  # Config is in pyproject.toml
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.0
     hooks:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,27 @@
+# Yamllint configuration
+# Comprehensive YAML linting (matches ruff's ALL rules philosophy)
+# Enable all rules by default with selective pragmatic disables
+
+extends: default
+
+rules:
+  # Line length - align with ruff's line-length = 100 for consistency
+  line-length:
+    max: 100
+    allow-non-breakable-inline-mappings: true
+
+  # Document start (---) - not always necessary, disable for practical use
+  document-start: disable
+
+  # Indentation - standard 2 spaces for YAML
+  indentation:
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+
+  # Comments - allow flexibility in comment formatting
+  comments:
+    min-spaces-from-content: 1
+
+  # Truthy values - disable overly strict checking (yes/no are common and clear)
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Yamllint Integration** - YAML file validation and linting
+  - Comprehensive configuration matching ruff's ALL rules philosophy
+  - Pre-commit hook for automated YAML linting
+  - Tox environment (yamllint) for standalone YAML checking
+  - Added to CI/CD pipeline for continuous YAML validation
+  - Configuration in .yamllint file (yamllint doesn't support pyproject.toml)
+  - Extends default configuration with selective pragmatic disables
+  - Line length: 100 (aligns with ruff's line-length)
+  - Document start: disabled (not always necessary)
+  - Truthy values: disabled (yes/no are common and clear)
+  - Fixed line-length issue in .github/workflows/ci.yml (converted to multi-line array)
 - **Validate-pyproject Integration** - pyproject.toml validation against PEP standards
   - Comprehensive validation matching ruff's ALL rules philosophy
   - Pre-commit hook for automated pyproject.toml validation
@@ -30,11 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to CI/CD pipeline for continuous spell checking
   - Configured with check-filenames and check-hidden enabled by default
   - Selective ignores for generated files and lock files
-- Comprehensive pre-commit hooks (35 total):
+- Comprehensive pre-commit hooks (36 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
   - Project validation hooks (1): validate-pyproject for pyproject.toml validation
+  - YAML linting hooks (1): yamllint for YAML file validation and linting
   - Spelling hooks (1): codespell for code and documentation spell checking
   - Markdown hooks (1): pymarkdown for markdown linting and formatting
   - UV hook (1): uv-lock for dependency lock file validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 35 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 36 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -110,9 +110,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (35 Comprehensive Checks)
+## Pre-commit Hooks (36 Comprehensive Checks)
 
-The project uses 35 pre-commit hooks for automatic code quality validation:
+The project uses 36 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -140,6 +140,9 @@ The project uses 35 pre-commit hooks for automatic code quality validation:
 
 **Project Validation Hooks (1 from validate-pyproject):**
 - `validate-pyproject`: Validates pyproject.toml against PEP 517, 518, 621, 631 standards
+
+**YAML Linting Hooks (1 from yamllint):**
+- `yamllint`: YAML file validation and linting (comprehensive by default)
 
 **Spelling Hooks (1 from codespell):**
 - `codespell`: Spell checking for code and documentation (comprehensive by default)
@@ -716,7 +719,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 35 hooks (meta, file quality, Python quality, project validation, spelling, markdown, UV, ruff, mypy)
+- **Pre-commit Hooks:** 36 hooks (meta, file quality, Python quality, project validation, YAML linting, spelling, markdown, UV, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (35 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (36 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -350,6 +350,7 @@ pre-commit autoupdate
 - **File quality** (18): Formatting, syntax, security (trailing-whitespace, check-yaml, detect-private-key, etc.)
 - **Python quality** (7): Code patterns (blanket-noqa, mock-methods, eval, type-annotations, etc.)
 - **Project validation** (1): pyproject.toml validation against PEP standards (validate-pyproject)
+- **YAML linting** (1): YAML file validation and linting (yamllint)
 - **Spelling** (1): Code and documentation spell checking (codespell)
 - **Markdown** (1): Markdown linting and formatting (pymarkdown)
 - **UV** (1): Dependency lock file validation (uv-lock)
@@ -513,7 +514,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 35 hooks (meta, pre-commit-hooks, pygrep-hooks, validate-pyproject, codespell, pymarkdown, uv, ruff, mypy)
+- **Pre-commit Hooks**: 36 hooks (meta, pre-commit-hooks, pygrep-hooks, validate-pyproject, yamllint, codespell, pymarkdown, uv, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,16 @@ quiet-level = 0  # Show all issues (comprehensive)
 # - PEP 631: Dependency specification
 # All validations are enabled by default, ensuring complete compliance
 
+# Yamllint configuration
+# Note: yamllint doesn't natively support pyproject.toml configuration
+# Configuration is in .yamllint file in the repository root
+# This section documents the configuration approach (matches ruff's ALL rules philosophy):
+# - Extends default configuration (comprehensive by default)
+# - Line length: 100 (aligns with ruff's line-length)
+# - Document start: disabled (not always necessary)
+# - Truthy values: disabled (yes/no are common and clear)
+# - Indentation: 2 spaces (standard for YAML)
+
 # PyMarkdown configuration
 [tool.pymarkdown]
 # Comprehensive by default (matches ruff's ALL rules philosophy)

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     codespell
     pymarkdown
     validate-pyproject
+    yamllint
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -160,6 +161,17 @@ commands_pre =
 commands =
     validate-pyproject {posargs:pyproject.toml}
 
+[testenv:yamllint]
+# YAML linting - check YAML files
+description = Lint YAML files with yamllint
+labels = quality
+skip_install = true
+deps = yamllint
+commands_pre =
+    yamllint --version
+commands =
+    yamllint {posargs:.}
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -242,6 +254,7 @@ deps =
     codespell
     pymarkdownlnt
     validate-pyproject[all]
+    yamllint
 commands_pre =
     ruff --version
     mypy --version
@@ -250,6 +263,7 @@ commands_pre =
     codespell --version
     pymarkdown version
     validate-pyproject --version
+    yamllint --version
 commands =
     ruff format --check src tests
     ruff check src tests
@@ -259,6 +273,7 @@ commands =
     codespell src tests docs *.md
     pymarkdown scan *.md docs
     validate-pyproject pyproject.toml
+    yamllint .
 
 # Fast test environment (no coverage)
 [testenv:fast]


### PR DESCRIPTION
## Summary
- Implements yamllint with configuration matching ruff's ALL rules philosophy
- Pre-commit hook for automated YAML linting
- Tox environment (yamllint) for standalone testing
- CI/CD integration via GitHub Actions

## Configuration
- Comprehensive configuration in .yamllint file
- Extends default configuration (all rules enabled by default)
- Selective pragmatic disables for practical use:
  - **Line length**: 100 characters (aligns with ruff's line-length)
  - **Document start**: disabled (--- not always necessary)
  - **Truthy values**: disabled (yes/no are common and clear)
  - **Indentation**: 2 spaces (standard for YAML)
  - **Comments**: flexible formatting (min 1 space from content)
- Integrated with pre-commit, tox, make, and GitHub CI

## Configuration Location
- Configuration in `.yamllint` file (yamllint doesn't support pyproject.toml)
- Added documentation note in pyproject.toml explaining the approach

## Code Improvements
- Fixed line-length violation in .github/workflows/ci.yml
- Converted tox-env matrix from single-line array to multi-line array
- Improves readability and maintainability of CI configuration

## Documentation
- Updated README.md with hook count (35 → 36)
- Updated CLAUDE.md with yamllint section
- Updated CHANGELOG.md with detailed changes

## Testing
All three testing methods passed:
- ✅ `pre-commit run yamllint --all-files`
- ✅ `tox -e yamllint`
- ✅ `make tox-yamllint`

## Test plan
- [x] Pre-commit hooks pass
- [x] Tox environment works
- [x] Makefile target works
- [x] Documentation updated
- [x] Fixed YAML formatting issues
- [ ] CI/CD pipeline passes