### PR TITLE
Add flake8 for comprehensive Python code linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           - pymarkdown
           - validate-pyproject
           - yamllint
+          - flake8
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,14 @@ repos:
     hooks:
       - id: uv-lock
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        # Comprehensive linting (matches ruff's ALL rules philosophy)
+        additional_dependencies: [flake8-pyproject]
+        args: []  # Config is in pyproject.toml via flake8-pyproject
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Flake8 Integration** - Python code linting and style checking
+  - Comprehensive configuration matching ruff's ALL rules philosophy as closely as possible
+  - Pre-commit hook for automated Python linting (complementary to ruff)
+  - Tox environment (flake8) for standalone linting
+  - Added to CI/CD pipeline for continuous code quality validation
+  - Configuration in pyproject.toml via flake8-pyproject plugin
+  - Line length: 100 (aligns with ruff's line-length)
+  - Max complexity: 10 (matches ruff's mccabe max-complexity)
+  - Per-file ignores for __init__.py and tests (matches ruff's approach)
+  - Note: Provides additional validation alongside ruff for comprehensive coverage
 - **Yamllint Integration** - YAML file validation and linting
   - Comprehensive configuration matching ruff's ALL rules philosophy
   - Pre-commit hook for automated YAML linting
@@ -41,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to CI/CD pipeline for continuous spell checking
   - Configured with check-filenames and check-hidden enabled by default
   - Selective ignores for generated files and lock files
-- Comprehensive pre-commit hooks (36 total):
+- Comprehensive pre-commit hooks (37 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
@@ -50,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Spelling hooks (1): codespell for code and documentation spell checking
   - Markdown hooks (1): pymarkdown for markdown linting and formatting
   - UV hook (1): uv-lock for dependency lock file validation
+  - Flake8 hooks (1): flake8 for Python code linting and style checking
   - Ruff hooks (2): ruff-check (linting), ruff-format (formatting)
   - MyPy hook (1): strict type checking
 - UV lock file (uv.lock) with 1,957 lines for deterministic dependency resolution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 36 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 37 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -110,9 +110,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (36 Comprehensive Checks)
+## Pre-commit Hooks (37 Comprehensive Checks)
 
-The project uses 36 pre-commit hooks for automatic code quality validation:
+The project uses 37 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -152,6 +152,9 @@ The project uses 36 pre-commit hooks for automatic code quality validation:
 
 **UV Hook (1 from uv-pre-commit):**
 - `uv-lock`: Maintains uv.lock file consistency with pyproject.toml
+
+**Flake8 Hooks (1 from pycqa/flake8):**
+- `flake8`: Python code linting and style checking (comprehensive configuration via flake8-pyproject)
 
 **Ruff Hooks (2 from ruff-pre-commit):**
 - `ruff-check`: Comprehensive linting with ALL rules (--fix, --exit-non-zero-on-fix)
@@ -719,7 +722,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 36 hooks (meta, file quality, Python quality, project validation, YAML linting, spelling, markdown, UV, ruff, mypy)
+- **Pre-commit Hooks:** 37 hooks (meta, file quality, Python quality, project validation, YAML linting, spelling, markdown, UV, flake8, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (36 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (37 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -354,6 +354,7 @@ pre-commit autoupdate
 - **Spelling** (1): Code and documentation spell checking (codespell)
 - **Markdown** (1): Markdown linting and formatting (pymarkdown)
 - **UV** (1): Dependency lock file validation (uv-lock)
+- **Flake8** (1): Python code linting and style checking (flake8)
 - **Ruff** (2): Comprehensive linting and formatting (ruff-check, ruff-format)
 - **MyPy** (1): Strict type checking
 
@@ -514,7 +515,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 36 hooks (meta, pre-commit-hooks, pygrep-hooks, validate-pyproject, yamllint, codespell, pymarkdown, uv, ruff, mypy)
+- **Pre-commit Hooks**: 37 hooks (meta, pre-commit-hooks, pygrep-hooks, validate-pyproject, yamllint, codespell, pymarkdown, uv, flake8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,39 @@ Issues = "https://github.com/bdperkin/nhl-scrabble/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/nhl_scrabble"]
 
+# Flake8 configuration
+# Note: flake8 doesn't natively support pyproject.toml
+# Using flake8-pyproject plugin to enable configuration here
+[tool.flake8]
+# Comprehensive linting (matches ruff's ALL rules philosophy as closely as possible)
+# Align with ruff's configuration
+max-line-length = 100
+extend-ignore = [
+    # Align with ruff's ignores where applicable
+    "E501",  # Line too long (handled by formatter)
+    "W503",  # Line break before binary operator (conflicts with modern style)
+    "E203",  # Whitespace before ':' (conflicts with black/ruff-format)
+]
+# Match ruff's target version and source paths
+per-file-ignores = [
+    "__init__.py:F401,F403",  # Unused imports in __init__.py (like ruff's per-file-ignores)
+    "tests/*:S101",  # Use of assert (pytest uses assert)
+]
+max-complexity = 10  # Match ruff's mccabe max-complexity
+exclude = [
+    ".git",
+    ".tox",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    "*.egg-info",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+]
+
 # Ruff configuration
 [tool.ruff]
 target-version = "py310"

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     pymarkdown
     validate-pyproject
     yamllint
+    flake8
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -172,6 +173,19 @@ commands_pre =
 commands =
     yamllint {posargs:.}
 
+[testenv:flake8]
+# Python linting - check Python code with flake8
+description = Lint Python code with flake8
+labels = quality
+skip_install = true
+deps =
+    flake8
+    flake8-pyproject
+commands_pre =
+    flake8 --version
+commands =
+    flake8 {posargs:src tests}
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -255,6 +269,8 @@ deps =
     pymarkdownlnt
     validate-pyproject[all]
     yamllint
+    flake8
+    flake8-pyproject
 commands_pre =
     ruff --version
     mypy --version
@@ -264,6 +280,7 @@ commands_pre =
     pymarkdown version
     validate-pyproject --version
     yamllint --version
+    flake8 --version
 commands =
     ruff format --check src tests
     ruff check src tests
@@ -274,6 +291,7 @@ commands =
     pymarkdown scan *.md docs
     validate-pyproject pyproject.toml
     yamllint .
+    flake8 src tests
 
 # Fast test environment (no coverage)
 [testenv:fast]


### PR DESCRIPTION
## Summary
- Implements flake8 with configuration matching ruff's ALL rules philosophy
- Pre-commit hook for automated Python linting
- Tox environment (flake8) for standalone testing
- CI/CD integration via GitHub Actions

## Configuration
- Comprehensive configuration in pyproject.toml via flake8-pyproject plugin
- Aligned with ruff's configuration where possible:
  - **Line length**: 100 (matches ruff's line-length)
  - **Max complexity**: 10 (matches ruff's mccabe max-complexity)
  - **Extend ignore**: E501, W503, E203 (aligns with ruff's practical exceptions)
  - **Per-file ignores**: __init__.py and tests/* (matches ruff's approach)
  - **Exclude patterns**: Same directories as ruff (.git, .tox, .venv, etc.)
- Integrated with pre-commit, tox, make, and GitHub CI

## Complementary Validation
- **Note**: Flake8 provides complementary validation alongside ruff
- Ruff already includes all flake8 functionality (designed as flake8 replacement)
- This integration adds an additional layer of validation for comprehensive coverage
- Both tools configured to align where possible for consistency

## Configuration Requirements
- Requires `flake8-pyproject` plugin for pyproject.toml support
- Flake8 doesn't natively support pyproject.toml configuration
- Plugin enables modern configuration approach consistent with other tools

## Documentation
- Updated README.md with hook count (36 → 37)
- Updated CLAUDE.md with flake8 section
- Updated CHANGELOG.md with detailed changes

## Testing
All three testing methods passed:
- ✅ `pre-commit run flake8 --all-files`
- ✅ `tox -e flake8`
- ✅ `make tox-flake8`

## Test plan
- [x] Pre-commit hooks pass
- [x] Tox environment works
- [x] Makefile target works
- [x] Documentation updated
- [x] Configuration aligned with ruff where possible
- [ ] CI/CD pipeline passes