### PR TITLE
Add absolufy-imports for absolute import enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           - validate-pyproject
           - yamllint
           - flake8
+          - absolufy-imports
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,14 @@ repos:
       # Text content checks
       - id: text-unicode-replacement-char
 
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+      - id: absolufy-imports
+        # Convert relative imports to absolute (matches ruff's ALL rules philosophy)
+        args: [--application-directories=src]
+        files: ^src/
+
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.23
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Absolufy-imports Integration** - Convert relative imports to absolute imports
+  - Comprehensive configuration matching ruff's ALL rules philosophy
+  - Pre-commit hook configured to process only src/ directory files
+  - Tox environment (absolufy-imports) with bash wrapper for glob expansion
+  - Added to CI/CD pipeline for continuous import normalization
+  - Configuration via command-line args: --application-directories=src (matches project src layout)
+  - Aligns with ruff's import handling and isort configuration
+  - Ensures consistent absolute imports throughout the codebase
 - **Mdformat Integration** - Markdown formatting with GitHub Flavored Markdown support
   - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
   - Pre-commit hook with mdformat-gfm and mdformat-tables plugins for GitHub Flavored Markdown support
@@ -60,10 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to CI/CD pipeline for continuous spell checking
   - Configured with check-filenames and check-hidden enabled by default
   - Selective ignores for generated files and lock files
-- Comprehensive pre-commit hooks (38 total):
+- Comprehensive pre-commit hooks (39 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
+  - Python import hooks (1): absolufy-imports for converting relative to absolute imports
   - Project validation hooks (1): validate-pyproject for pyproject.toml validation
   - YAML linting hooks (1): yamllint for YAML file validation and linting
   - Spelling hooks (1): codespell for code and documentation spell checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 38 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 39 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (38 Comprehensive Checks)
+## Pre-commit Hooks (39 Comprehensive Checks)
 
-The project uses 38 pre-commit hooks for automatic code quality validation:
+The project uses 39 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -146,6 +146,10 @@ The project uses 38 pre-commit hooks for automatic code quality validation:
 - `python-no-log-warn`: Enforce logging.warning() vs deprecated logging.warn()
 - `python-use-type-annotations`: Enforce PEP 484 annotations vs type comments
 - `text-unicode-replacement-char`: Detect Unicode replacement character (U+FFFD)
+
+**Python Import Hooks (1 from absolufy-imports):**
+
+- `absolufy-imports`: Convert relative imports to absolute imports (comprehensive by default)
 
 **Project Validation Hooks (1 from validate-pyproject):**
 
@@ -759,7 +763,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 38 hooks (meta, file quality, Python quality, project validation, YAML linting, spelling, markdown linting, markdown formatting, UV, flake8, ruff, mypy)
+- **Pre-commit Hooks:** 39 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown linting, markdown formatting, UV, flake8, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (38 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (39 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -350,6 +350,7 @@ pre-commit autoupdate
 - **Meta hooks** (3): Configuration validation (check-hooks-apply, check-useless-excludes, sync-pre-commit-deps)
 - **File quality** (18): Formatting, syntax, security (trailing-whitespace, check-yaml, detect-private-key, etc.)
 - **Python quality** (7): Code patterns (blanket-noqa, mock-methods, eval, type-annotations, etc.)
+- **Python imports** (1): Convert relative imports to absolute (absolufy-imports)
 - **Project validation** (1): pyproject.toml validation against PEP standards (validate-pyproject)
 - **YAML linting** (1): YAML file validation and linting (yamllint)
 - **Spelling** (1): Code and documentation spell checking (codespell)
@@ -516,7 +517,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 38 hooks (meta, pre-commit-hooks, pygrep-hooks, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, uv, flake8, ruff, mypy)
+- **Pre-commit Hooks**: 39 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, uv, flake8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,6 +385,14 @@ quiet-level = 0  # Show all issues (comprehensive)
 # - Truthy values: disabled (yes/no are common and clear)
 # - Indentation: 2 spaces (standard for YAML)
 
+# Absolufy-imports configuration
+# Note: absolufy-imports doesn't natively support pyproject.toml configuration
+# Configuration is via command-line arguments in pre-commit and tox
+# This section documents the configuration approach (matches ruff's ALL rules philosophy):
+# - Convert all relative imports to absolute imports (comprehensive by default)
+# - Application directories: src (matches project src layout)
+# - Aligns with ruff's import handling and isort configuration
+
 # Mdformat configuration
 [tool.mdformat]
 # Comprehensive markdown formatting (matches ruff's ALL rules philosophy)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     validate-pyproject
     yamllint
     flake8
+    absolufy-imports
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -202,6 +203,16 @@ commands_pre =
 commands =
     flake8 {posargs:src tests}
 
+[testenv:absolufy-imports]
+# Convert relative imports to absolute imports
+description = Convert relative imports to absolute imports
+labels = quality
+skip_install = true
+allowlist_externals = bash
+deps = absolufy-imports
+commands =
+    bash -c 'absolufy-imports --application-directories=src src/**/*.py'
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -291,6 +302,7 @@ deps =
     yamllint
     flake8
     flake8-pyproject
+    absolufy-imports
 commands_pre =
     ruff --version
     mypy --version
@@ -314,6 +326,7 @@ commands =
     validate-pyproject pyproject.toml
     yamllint .
     flake8 src tests
+    bash -c 'absolufy-imports --application-directories=src src/**/*.py'
 
 # Fast test environment (no coverage)
 [testenv:fast]

--- a/tox.ini
+++ b/tox.ini
@@ -210,6 +210,7 @@ labels = quality
 skip_install = true
 allowlist_externals = bash
 deps = absolufy-imports
+commands_pre =
 commands =
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
 


### PR DESCRIPTION
## Summary

Integrate **absolufy-imports** to convert relative imports to absolute imports throughout the codebase, ensuring consistent import style that aligns with ruff's import handling and isort configuration. This is the 19th quality tool integration following the established pattern of comprehensive configuration matching ruff's ALL rules philosophy.

## Changes

### Configuration
- **Command-line args**: `--application-directories=src` (matches project src layout)
- **Scope**: Only processes src/ directory files (tests use relative imports by convention)
- **Documentation**: Configuration documented in pyproject.toml (tool doesn't support native config)

### Integration Points
1. **Pre-commit hook**: Added absolufy-imports with files filter `^src/` to `.pre-commit-config.yaml`
2. **Tox environment**: Created `[testenv:absolufy-imports]` with bash wrapper for glob expansion
3. **CI/CD**: Added absolufy-imports to GitHub Actions matrix
4. **Documentation**: Updated all docs to reflect 38 → 39 hooks

### Impact
- Enforces absolute imports in src/ directory
- Aligns with ruff's ALL rules philosophy
- Works alongside ruff's isort configuration
- All pre-commit hooks passing
- All tox environments passing

## Test Results

✅ Pre-commit: `pre-commit run absolufy-imports --all-files` - Passed
✅ Tox: `tox -e absolufy-imports` - Passed  
✅ Make: `make tox-absolufy-imports` - Passed
✅ All hooks: `pre-commit run --all-files` - Passed (39 hooks)

## Alignment with Project Philosophy

This integration follows the project's "ALL rules" philosophy:
- Comprehensive by default (converts all relative imports to absolute)
- Selective scope (src/ only, excluding tests)
- Consistent across all integration points (pre-commit, tox, CI)
- Configuration documented in pyproject.toml (even though not natively supported)

## Files Changed
- Configuration: `.pre-commit-config.yaml`, `pyproject.toml`, `tox.ini`, `.github/workflows/ci.yml`
- Documentation: `README.md`, `CLAUDE.md`, `CHANGELOG.md` (hook counts updated 38→39)

## Related PRs
Part of systematic quality tool integration series (validate-pyproject, yamllint, codespell, pymarkdown, flake8, mdformat, **absolufy-imports**)