### PR TITLE
Add autopep8 for PEP 8 auto-formatting with conflict resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - yamllint
           - flake8
           - absolufy-imports
+          - autopep8
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,14 @@ repos:
         additional_dependencies: [flake8-pyproject]
         args: []  # Config is in pyproject.toml via flake8-pyproject
 
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.0.4
+    hooks:
+      - id: autopep8
+        # Comprehensive PEP 8 formatting (runs before ruff-format)
+        # Note: May conflict with ruff-format; autopep8 runs first, ruff-format finalizes
+        args: [--in-place, --aggressive, --aggressive]  # Additional config in pyproject.toml
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Autopep8 Integration** - PEP 8 auto-formatting with aggressive conflict resolution
+  - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
+  - Pre-commit hook runs BEFORE ruff-format (autopep8 first pass, ruff-format finalization)
+  - Tox environment (autopep8) for standalone formatting checks
+  - Added to CI/CD pipeline for continuous code formatting validation
+  - Configuration: max_line_length=100, aggressive=2, ignores E501/W503/E203 (align with ruff)
+  - Hook order: autopep8 → ruff-check → ruff-format (allows both formatters to work together)
+  - Note: Potential conflicts managed by running autopep8 first, then ruff-format finalizes
 - **Absolufy-imports Integration** - Convert relative imports to absolute imports
   - Comprehensive configuration matching ruff's ALL rules philosophy
   - Pre-commit hook configured to process only src/ directory files
@@ -68,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to CI/CD pipeline for continuous spell checking
   - Configured with check-filenames and check-hidden enabled by default
   - Selective ignores for generated files and lock files
-- Comprehensive pre-commit hooks (39 total):
+- Comprehensive pre-commit hooks (40 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
@@ -79,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Markdown hooks (2): pymarkdown for markdown linting, mdformat for markdown formatting
   - UV hook (1): uv-lock for dependency lock file validation
   - Flake8 hooks (1): flake8 for Python code linting and style checking
-  - Ruff hooks (2): ruff-check (linting), ruff-format (formatting)
+  - Autopep8 hooks (1): autopep8 for PEP 8 auto-formatting (runs before ruff-format)
+  - Ruff hooks (2): ruff-check (linting), ruff-format (formatting finalization)
   - MyPy hook (1): strict type checking
 - UV lock file (uv.lock) with 1,957 lines for deterministic dependency resolution
 - Comprehensive UV configuration in pyproject.toml aligned with ruff's "ALL rules" philosophy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 39 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 40 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (39 Comprehensive Checks)
+## Pre-commit Hooks (40 Comprehensive Checks)
 
-The project uses 39 pre-commit hooks for automatic code quality validation:
+The project uses 40 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -175,6 +175,10 @@ The project uses 39 pre-commit hooks for automatic code quality validation:
 **Flake8 Hooks (1 from pycqa/flake8):**
 
 - `flake8`: Python code linting and style checking (comprehensive configuration via flake8-pyproject)
+
+**Autopep8 Hooks (1 from hhatto/autopep8):**
+
+- `autopep8`: PEP 8 auto-formatting (runs before ruff-format, aggressive level 2)
 
 **Ruff Hooks (2 from ruff-pre-commit):**
 
@@ -763,7 +767,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 39 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown linting, markdown formatting, UV, flake8, ruff, mypy)
+- **Pre-commit Hooks:** 40 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown linting, markdown formatting, UV, flake8, autopep8, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (39 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (40 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -352,6 +352,7 @@ pre-commit autoupdate
 - **Python quality** (7): Code patterns (blanket-noqa, mock-methods, eval, type-annotations, etc.)
 - **Python imports** (1): Convert relative imports to absolute (absolufy-imports)
 - **Project validation** (1): pyproject.toml validation against PEP standards (validate-pyproject)
+- **Python formatting** (1): PEP 8 auto-formatting (autopep8)
 - **YAML linting** (1): YAML file validation and linting (yamllint)
 - **Spelling** (1): Code and documentation spell checking (codespell)
 - **Markdown** (2): Markdown linting (pymarkdown) and formatting (mdformat)
@@ -517,7 +518,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 39 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, uv, flake8, ruff, mypy)
+- **Pre-commit Hooks**: 40 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, uv, flake8, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,19 @@ exclude = [
     ".ruff_cache",
 ]
 
+# Autopep8 configuration
+[tool.autopep8]
+# Comprehensive PEP 8 formatting (matches ruff's ALL rules philosophy as closely as possible)
+# Align with ruff's configuration
+max_line_length = 100  # Match ruff's line-length
+aggressive = 2  # Apply aggressive fixes (level 2 for comprehensive but safe changes)
+# Ignore errors that conflict with ruff-format or are handled better by ruff
+ignore = "E501,W503,E203"  # Comma-separated list
+# Selectively enable certain fixes
+select = ""  # Empty = enable all fixes except ignored
+# Number of jobs for parallel processing (0 = auto-detect)
+jobs = 0
+
 # Ruff configuration
 [tool.ruff]
 target-version = "py310"

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
     yamllint
     flake8
     absolufy-imports
+    autopep8
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -214,6 +215,17 @@ commands_pre =
 commands =
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
 
+[testenv:autopep8]
+# PEP 8 formatting - auto-format Python code
+description = Format Python code with autopep8
+labels = format, quality
+skip_install = true
+deps = autopep8
+commands_pre =
+    autopep8 --version
+commands =
+    autopep8 --diff --recursive src tests {posargs}
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -304,6 +316,7 @@ deps =
     flake8
     flake8-pyproject
     absolufy-imports
+    autopep8
 commands_pre =
     ruff --version
     mypy --version
@@ -315,6 +328,7 @@ commands_pre =
     validate-pyproject --version
     yamllint --version
     flake8 --version
+    autopep8 --version
 commands =
     ruff format --check src tests
     ruff check src tests
@@ -328,6 +342,7 @@ commands =
     yamllint .
     flake8 src tests
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
+    autopep8 --diff --recursive src tests
 
 # Fast test environment (no coverage)
 [testenv:fast]


### PR DESCRIPTION
## Summary

Integrate **autopep8** as an additional PEP 8 formatter using **aggressive conflict resolution (Option C)** to work alongside ruff-format. This dual-formatter approach runs autopep8 first for PEP 8 compliance, then ruff-format for final consistency. This is the 20th quality tool integration following the established pattern of comprehensive configuration matching ruff's ALL rules philosophy.

## Changes

### Configuration
- **pyproject.toml**: Added `[tool.autopep8]` section with comprehensive settings
  - `max_line_length = 100` - Aligns with ruff's line-length
  - `aggressive = 2` - Level 2 aggressive fixes (comprehensive but safe)
  - `ignore = "E501,W503,E203"` - Conflicts with ruff-format
  - `jobs = 0` - Auto-detect cores for parallel processing

### Integration Points
1. **Pre-commit hook**: Added autopep8 BEFORE ruff-format (ordered conflict resolution)
   - Args: `--in-place --aggressive --aggressive` (level 2 aggressive)
2. **Tox environment**: Created `[testenv:autopep8]` with `--diff --recursive` for validation
3. **CI/CD**: Added autopep8 to GitHub Actions matrix
4. **Documentation**: Updated all docs to reflect 39 → 40 hooks

### Conflict Resolution Strategy (Option C)

**Hook Order (Critical):**
1. autopep8 runs first (PEP 8 initial compliance)
2. ruff-format runs second (final formatting consistency)

**Shared Configuration:**
- Both use `line-length = 100`
- Both ignore E501, W503, E203
- Autopep8 aggressive=2 aligns with ruff's comprehensive approach

**Potential Conflicts:**
- Managed through hook ordering
- Autopep8 makes initial PEP 8 fixes
- Ruff-format finalizes with modern best practices
- Testing confirms both formatters coexist successfully

## Test Results

✅ Pre-commit: `pre-commit run autopep8 --all-files` - Passed
✅ Tox: `tox -e autopep8` - Passed  
✅ Make: `make tox-autopep8` - Passed
✅ All hooks: `pre-commit run --all-files` - Passed (40 hooks)
✅ No formatter conflicts detected

## Alignment with Project Philosophy

This integration follows the project's "ALL rules" philosophy:
- Comprehensive by default (autopep8 aggressive=2)
- Conflict resolution through configuration alignment
- Consistent across all integration points (pre-commit, tox, CI)
- Configuration in pyproject.toml (central configuration file)

## Design Decision: Option C

Selected **Option C: Aggressive conflict resolution** per user request:
- ✅ Dual formatters (autopep8 + ruff-format)
- ✅ Conflict resolution through hook ordering
- ✅ Shared ignore lists to prevent fights
- ✅ Both formatters configured identically where possible

Alternative options rejected:
- ❌ Option A: Don't add (not requested)
- ❌ Option B: Check-only mode (user chose aggressive)
- ❌ Option D: Replace ruff-format (loses modern features)

## Files Changed
- Configuration: `.pre-commit-config.yaml`, `pyproject.toml`, `tox.ini`, `.github/workflows/ci.yml`
- Documentation: `README.md`, `CLAUDE.md`, `CHANGELOG.md` (hook counts updated 39→40)

## Related PRs
Part of systematic quality tool integration series (validate-pyproject, yamllint, codespell, pymarkdown, flake8, mdformat, absolufy-imports, **autopep8**)