### PR TITLE
Add rstcheck for RST syntax checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           - absolufy-imports
           - autopep8
           - doc8
+          - rstcheck
 
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,14 @@ repos:
         args: []  # Config is in pyproject.toml
         files: \.(rst|txt)$
 
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.0
+    hooks:
+      - id: rstcheck
+        # Comprehensive RST syntax checking (matches ruff's ALL rules philosophy)
+        args: []  # Config is in pyproject.toml
+        additional_dependencies: [sphinx]
+
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.5.18
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rstcheck Integration** - RST syntax checking and validation
+  - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
+  - Pre-commit hook with Sphinx integration for code block validation
+  - Tox environment (rstcheck) for standalone RST syntax checking
+  - Added to CI/CD pipeline for continuous documentation syntax validation
+  - Configuration: report_level="INFO" (most comprehensive), no ignores for complete validation
+  - Works alongside doc8: rstcheck handles syntax/validation, doc8 handles style/formatting
+  - Complete RST coverage: syntax (rstcheck) + style (doc8)
 - **Doc8 Integration** - RST documentation linting
   - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
   - Pre-commit hook for RST (.rst, .txt) file validation
@@ -84,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to CI/CD pipeline for continuous spell checking
   - Configured with check-filenames and check-hidden enabled by default
   - Selective ignores for generated files and lock files
-- Comprehensive pre-commit hooks (41 total):
+- Comprehensive pre-commit hooks (42 total):
   - Meta hooks (3): check-hooks-apply, check-useless-excludes, sync-pre-commit-deps
   - File quality hooks (18): whitespace, syntax, security, git checks
   - Python quality hooks (7): noqa, type-ignore, mock, eval, annotations checks
@@ -93,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - YAML linting hooks (1): yamllint for YAML file validation and linting
   - Spelling hooks (1): codespell for code and documentation spell checking
   - Markdown hooks (2): pymarkdown for markdown linting, mdformat for markdown formatting
-  - Documentation hooks (1): doc8 for RST documentation linting
+  - Documentation hooks (2): doc8 for RST style linting, rstcheck for RST syntax checking
   - UV hook (1): uv-lock for dependency lock file validation
   - Flake8 hooks (1): flake8 for Python code linting and style checking
   - Autopep8 hooks (1): autopep8 for PEP 8 auto-formatting (runs before ruff-format)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 41 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 42 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (41 Comprehensive Checks)
+## Pre-commit Hooks (42 Comprehensive Checks)
 
-The project uses 41 pre-commit hooks for automatic code quality validation:
+The project uses 42 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -168,9 +168,10 @@ The project uses 41 pre-commit hooks for automatic code quality validation:
 - `pymarkdown`: Markdown linting (comprehensive by default)
 - `mdformat`: Markdown formatting with plugins (mdformat-gfm, mdformat-tables)
 
-**Documentation Hooks (1 from PyCQA/doc8):**
+**Documentation Hooks (2 from PyCQA/doc8 and rstcheck/rstcheck):**
 
-- `doc8`: RST documentation linting (comprehensive by default, max-line-length=100)
+- `doc8`: RST style linting (comprehensive by default, max-line-length=100)
+- `rstcheck`: RST syntax checking (report_level=INFO, validates code blocks with Sphinx)
 
 **UV Hook (1 from uv-pre-commit):**
 
@@ -771,7 +772,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 41 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown linting, markdown formatting, RST documentation, UV, flake8, autopep8, ruff, mypy)
+- **Pre-commit Hooks:** 42 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown linting, markdown formatting, RST style, RST syntax, UV, flake8, autopep8, ruff, mypy)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (41 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (42 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -356,7 +356,7 @@ pre-commit autoupdate
 - **YAML linting** (1): YAML file validation and linting (yamllint)
 - **Spelling** (1): Code and documentation spell checking (codespell)
 - **Markdown** (2): Markdown linting (pymarkdown) and formatting (mdformat)
-- **Documentation** (1): RST documentation linting (doc8)
+- **Documentation** (2): RST style linting (doc8) and syntax checking (rstcheck)
 - **UV** (1): Dependency lock file validation (uv-lock)
 - **Flake8** (1): Python code linting and style checking (flake8)
 - **Ruff** (2): Comprehensive linting and formatting (ruff-check, ruff-format)
@@ -519,7 +519,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 41 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, uv, flake8, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 42 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -406,6 +406,18 @@ quiet-level = 0  # Show all issues (comprehensive)
 # - Application directories: src (matches project src layout)
 # - Aligns with ruff's import handling and isort configuration
 
+# Rstcheck configuration
+[tool.rstcheck]
+# Comprehensive RST syntax checking (matches ruff's ALL rules philosophy)
+# Report levels: 1=info, 2=warning, 3=error, 4=severe
+report_level = "INFO"  # Most comprehensive (report everything)
+# Ignore paths (align with other tool exclusions)
+ignore_directives = []  # Empty for comprehensive checking
+ignore_roles = []  # Empty for comprehensive checking
+ignore_substitutions = []  # Empty for comprehensive checking
+ignore_languages = []  # Empty for comprehensive checking
+ignore_messages = ""  # Empty for comprehensive checking
+
 # Doc8 configuration
 [tool.doc8]
 # Comprehensive RST documentation linting (matches ruff's ALL rules philosophy)

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ envlist =
     absolufy-imports
     autopep8
     doc8
+    rstcheck
 minversion = 4.0
 isolated_build = true
 skip_missing_interpreters = true
@@ -238,6 +239,19 @@ commands_pre =
 commands =
     doc8 {posargs:docs}
 
+[testenv:rstcheck]
+# RST syntax checking - validate reStructuredText files
+description = Check RST syntax with rstcheck
+labels = quality, docs
+skip_install = true
+deps =
+    rstcheck
+    sphinx
+commands_pre =
+    rstcheck --version
+commands =
+    rstcheck --recursive {posargs:docs}
+
 [testenv:check]
 # Comprehensive pre-commit checks
 description = Run all checks before commit (quality + tests)
@@ -330,6 +344,8 @@ deps =
     absolufy-imports
     autopep8
     doc8
+    rstcheck
+    sphinx
 commands_pre =
     ruff --version
     mypy --version
@@ -343,6 +359,7 @@ commands_pre =
     flake8 --version
     autopep8 --version
     doc8 --version
+    rstcheck --version
 commands =
     ruff format --check src tests
     ruff check src tests
@@ -358,6 +375,7 @@ commands =
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
     autopep8 --diff --recursive src tests
     doc8 docs
+    rstcheck --recursive docs
 
 # Fast test environment (no coverage)
 [testenv:fast]


### PR DESCRIPTION
## Summary

Integrate **rstcheck** to validate reStructuredText (RST) syntax and code blocks, providing comprehensive RST validation alongside doc8's style linting. This dual-tool approach ensures complete RST documentation quality: doc8 handles style/formatting, rstcheck handles syntax/validation. This is the 22nd quality tool integration following the established pattern of comprehensive configuration matching ruff's ALL rules philosophy.

## Changes

### Configuration
- **pyproject.toml**: Added `[tool.rstcheck]` section with comprehensive settings
  - `report_level = "INFO"` - Most comprehensive reporting (reports everything)
  - `ignore_directives = []` - No ignores for comprehensive checking
  - `ignore_roles = []` - No ignores for comprehensive checking
  - `ignore_substitutions = []` - No ignores for comprehensive checking
  - `ignore_languages = []` - No ignores for comprehensive checking
  - `ignore_messages = ""` - No ignores for comprehensive checking

### Integration Points
1. **Pre-commit hook**: Added rstcheck with Sphinx as additional dependency (for code block validation)
2. **Tox environment**: Created `[testenv:rstcheck]` with `--recursive` for directory scanning
3. **CI/CD**: Added rstcheck to GitHub Actions matrix
4. **Documentation**: Updated all docs to reflect 41 → 42 hooks

### Complete RST Coverage Strategy

**Dual-tool validation approach:**
- **rstcheck**: Syntax checking, code block validation, Sphinx directive validation
- **doc8**: Style linting, line-length, file encoding, formatting rules

**Why both tools:**
- Different focus areas (syntax vs style)
- Complementary validation (rstcheck finds syntax errors, doc8 finds style issues)
- Complete coverage (no gaps in RST quality validation)

**Alignment:**
- Both configured for comprehensive checking (ALL rules philosophy)
- Both work on same file types (.rst, .txt)
- No configuration conflicts

## Test Results

✅ Pre-commit: `pre-commit run rstcheck --all-files` - Passed
✅ Tox: `tox -e rstcheck` - Passed  
✅ Make: `make tox-rstcheck` - Passed
✅ All hooks: `pre-commit run --all-files` - Passed (42 hooks)

## Alignment with Project Philosophy

This integration follows the project's "ALL rules" philosophy:
- Comprehensive by default (report_level=INFO)
- No ignores (all lists empty, comprehensive checking)
- Configuration in pyproject.toml (central configuration)
- Consistent across all integration points (pre-commit, tox, CI)

## Files Changed
- Configuration: `.pre-commit-config.yaml`, `pyproject.toml`, `tox.ini`, `.github/workflows/ci.yml`
- Documentation: `README.md`, `CLAUDE.md`, `CHANGELOG.md` (hook counts updated 41→42)

## Related PRs
Part of systematic quality tool integration series (validate-pyproject, yamllint, codespell, pymarkdown, flake8, mdformat, absolufy-imports, autopep8, doc8, **rstcheck**)