### PR TITLE
Add docformatter for Python docstring formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - yamllint
           - flake8
           - absolufy-imports
+          - docformatter
           - autopep8
           - doc8
           - rstcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,10 @@ jobs:
         with:
           enable-cache: false
 
+      - name: Install docformatter for pre-commit
+        run: |
+          uv pip install docformatter --system
+
       - name: Run pre-commit with UV
         uses: pre-commit/action@v3.0.0
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,6 +132,17 @@ repos:
         additional_dependencies: [flake8-pyproject]
         args: []  # Config is in pyproject.toml via flake8-pyproject
 
+  - repo: local
+    hooks:
+      - id: docformatter
+        name: docformatter
+        # Comprehensive docstring formatting (matches ruff's ALL rules philosophy)
+        description: Format Python docstrings
+        entry: docformatter
+        args: [--in-place, --wrap-summaries, "100", --wrap-descriptions, "100"]
+        language: system
+        types: [python]
+
   - repo: https://github.com/hhatto/autopep8
     rev: v2.0.4
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docformatter Integration** - Python docstring formatting
+  - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
+  - Pre-commit hook (local) for automatic docstring formatting
+  - Tox environment (docformatter) for standalone docstring formatting checks
+  - Added to CI/CD pipeline for continuous docstring formatting validation
+  - Configuration: wrap_length=100, wrap_summaries=100, wrap_descriptions=100 (match ruff)
+  - Style: PEP 257 with pragmatic settings (no forced multi-line for short docstrings)
+  - Ruff integration: disabled ruff's docstring-code-format to avoid conflicts, added D413 to ignore list
+  - Works alongside ruff-format: docformatter handles docstrings, ruff handles code
 - **Rstcheck Integration** - RST syntax checking and validation
   - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
   - Pre-commit hook with Sphinx integration for code block validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 42 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 43 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (42 Comprehensive Checks)
+## Pre-commit Hooks (43 Comprehensive Checks)
 
-The project uses 42 pre-commit hooks for automatic code quality validation:
+The project uses 43 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -180,6 +180,10 @@ The project uses 42 pre-commit hooks for automatic code quality validation:
 **Flake8 Hooks (1 from pycqa/flake8):**
 
 - `flake8`: Python code linting and style checking (comprehensive configuration via flake8-pyproject)
+
+**Docformatter Hooks (1 from local):**
+
+- `docformatter`: Python docstring formatting (wrap-length=100, PEP 257 style)
 
 **Autopep8 Hooks (1 from hhatto/autopep8):**
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ pre-commit autoupdate
 - **Python imports** (1): Convert relative imports to absolute (absolufy-imports)
 - **Project validation** (1): pyproject.toml validation against PEP standards (validate-pyproject)
 - **Python formatting** (1): PEP 8 auto-formatting (autopep8)
+- **Docstring formatting** (1): Python docstring formatting (docformatter)
 - **YAML linting** (1): YAML file validation and linting (yamllint)
 - **Spelling** (1): Code and documentation spell checking (codespell)
 - **Markdown** (2): Markdown linting (pymarkdown) and formatting (mdformat)
@@ -519,7 +520,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 42 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 43 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, docformatter, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,21 @@ select = ""  # Empty = enable all fixes except ignored
 # Number of jobs for parallel processing (0 = auto-detect)
 jobs = 0
 
+# Docformatter configuration
+[tool.docformatter]
+# Comprehensive docstring formatting (matches ruff's ALL rules philosophy)
+# Align with ruff's configuration
+wrap_length = 100  # Match ruff's line-length
+wrap_summaries = 100  # Match ruff's line-length
+wrap_descriptions = 100  # Match ruff's line-length
+black = false  # Don't force Black-style multi-line for short docstrings
+style = "pep257"  # Follow PEP 257 docstring conventions
+make_summary_multi_line = false  # Only make multi-line when necessary
+close_quotes_on_newline = false  # Keep closing quotes on same line for short docstrings
+pre_summary_newline = false  # Don't add newline before summary (PEP 257 default)
+# Exclude patterns (align with other tool exclusions)
+exclude = [".git", ".tox", ".venv", "venv", "build", "dist", "*.egg-info"]
+
 # Ruff configuration
 [tool.ruff]
 target-version = "py310"
@@ -177,6 +192,7 @@ ignore = [
     "D105",    # Missing docstring in magic method
     "D106",    # Missing docstring in public nested class
     "D107",    # Missing docstring in __init__
+    "D413",    # Missing blank line after last section (conflicts with docformatter)
 
     # Stylistic choices that may be too opinionated
     "FBT001",  # Boolean positional arg in function definition
@@ -250,7 +266,7 @@ known-first-party = ["nhl_scrabble"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
-docstring-code-format = true
+docstring-code-format = false  # Use docformatter for docstring formatting
 
 # MyPy configuration
 [tool.mypy]

--- a/src/nhl_scrabble/api/nhl_client.py
+++ b/src/nhl_scrabble/api/nhl_client.py
@@ -32,7 +32,6 @@ class NHLApiClient:
         timeout: Request timeout in seconds
         retries: Number of retry attempts for failed requests
         rate_limit_delay: Delay in seconds between requests to avoid rate limiting
-
     """
 
     BASE_URL = "https://api-web.nhle.com/v1"
@@ -49,7 +48,6 @@ class NHLApiClient:
             timeout: Request timeout in seconds (default: 10)
             retries: Number of retry attempts for failed requests (default: 3)
             rate_limit_delay: Delay in seconds between requests (default: 0.3)
-
         """
         self.timeout = timeout
         self.retries = retries
@@ -77,7 +75,6 @@ class NHLApiClient:
             >>> teams = client.get_teams()
             >>> "TOR" in teams
             True
-
         """
         url = f"{self.BASE_URL}/standings/now"
         logger.info("Fetching NHL teams from standings endpoint")
@@ -130,7 +127,6 @@ class NHLApiClient:
             >>> roster = client.get_team_roster("TOR")
             >>> "forwards" in roster
             True
-
         """
         url = f"{self.BASE_URL}/roster/{team_abbrev}/current"
         logger.debug(f"Fetching roster for {team_abbrev}")

--- a/src/nhl_scrabble/cli.py
+++ b/src/nhl_scrabble/cli.py
@@ -33,8 +33,8 @@ console = Console()
 def cli() -> None:
     """NHL Roster Scrabble Score Analyzer.
 
-    Fetch NHL roster data and calculate Scrabble scores for player names.
-    Generate comprehensive reports showing team, division, and conference standings.
+    Fetch NHL roster data and calculate Scrabble scores for player names. Generate comprehensive
+    reports showing team, division, and conference standings.
     """
 
 
@@ -87,7 +87,6 @@ def analyze(
         nhl-scrabble analyze --verbose
         nhl-scrabble analyze --output report.txt
         nhl-scrabble analyze --format json --output report.json
-
     """
     # Setup logging
     setup_logging(verbose=verbose)
@@ -142,7 +141,6 @@ def run_analysis(config: Config) -> str:
 
     Raises:
         NHLApiError: If there are issues fetching data from NHL API
-
     """
     # Initialize components
     api_client = NHLApiClient(
@@ -225,7 +223,6 @@ def generate_json_report(
 
     Returns:
         JSON string
-
     """
     import json
     from dataclasses import asdict

--- a/src/nhl_scrabble/config.py
+++ b/src/nhl_scrabble/config.py
@@ -19,7 +19,6 @@ class Config:
         top_team_players_count: Number of top players per team to show
         verbose: Enable verbose logging
         output_format: Output format (text, json, html)
-
     """
 
     api_timeout: int = 10
@@ -52,7 +51,6 @@ class Config:
             >>> config = Config.from_env()
             >>> config.api_timeout
             15
-
         """
         # Load .env file if it exists
         load_dotenv()
@@ -72,7 +70,6 @@ class Config:
 
         Returns:
             Dictionary representation of the configuration
-
         """
         return {
             "api_timeout": self.api_timeout,

--- a/src/nhl_scrabble/logging_config.py
+++ b/src/nhl_scrabble/logging_config.py
@@ -16,7 +16,6 @@ def setup_logging(verbose: bool = False, json_output: bool = False) -> None:
         >>> setup_logging(verbose=True)
         >>> logger = logging.getLogger(__name__)
         >>> logger.debug("This will be shown")
-
     """
     log_level = logging.DEBUG if verbose else logging.INFO
 
@@ -62,7 +61,6 @@ class JSONFormatter(logging.Formatter):
 
         Returns:
             JSON string representation of log record
-
         """
         import json
 

--- a/src/nhl_scrabble/models/player.py
+++ b/src/nhl_scrabble/models/player.py
@@ -17,7 +17,6 @@ class PlayerScore:
         team: Team abbreviation (e.g., 'TOR', 'MTL')
         division: Division name
         conference: Conference name
-
     """
 
     first_name: str

--- a/src/nhl_scrabble/models/standings.py
+++ b/src/nhl_scrabble/models/standings.py
@@ -14,7 +14,6 @@ class DivisionStandings:
         teams: List of team abbreviations in this division
         player_count: Total number of players in the division
         avg_per_team: Average score per team
-
     """
 
     name: str
@@ -38,7 +37,6 @@ class ConferenceStandings:
         teams: List of team abbreviations in this conference
         player_count: Total number of players in the conference
         avg_per_team: Average score per team
-
     """
 
     name: str
@@ -72,7 +70,6 @@ class PlayoffTeam:
         in_playoffs: Whether team has clinched a playoff spot
         division_rank: Rank within the division (1-based)
         status_indicator: Playoff status (p=Presidents', z=Conference, y=Division, x=Playoff, e=Eliminated)
-
     """
 
     abbrev: str

--- a/src/nhl_scrabble/models/team.py
+++ b/src/nhl_scrabble/models/team.py
@@ -16,7 +16,6 @@ class TeamScore:
         division: Division name
         conference: Conference name
         avg_per_player: Average score per player (computed)
-
     """
 
     abbrev: str

--- a/src/nhl_scrabble/processors/playoff_calculator.py
+++ b/src/nhl_scrabble/processors/playoff_calculator.py
@@ -40,7 +40,6 @@ class PlayoffCalculator:
             >>> standings = calculator.calculate_playoff_standings(team_scores)
             >>> "Eastern" in standings
             True
-
         """
         logger.info("Calculating playoff standings")
 
@@ -82,7 +81,6 @@ class PlayoffCalculator:
 
         Returns:
             Dictionary mapping division names to lists of PlayoffTeam objects
-
         """
         teams_by_division: dict[str, list[PlayoffTeam]] = defaultdict(list)
 
@@ -109,7 +107,6 @@ class PlayoffCalculator:
 
         Returns:
             Tuple of (playoff_teams dict, all_teams list)
-
         """
         playoff_teams: dict[str, PlayoffTeam] = {}
         all_teams: list[PlayoffTeam] = []
@@ -144,7 +141,6 @@ class PlayoffCalculator:
 
         Returns:
             Dictionary mapping conference names to lists of wild card teams
-
         """
         wild_cards: dict[str, list[PlayoffTeam]] = {}
 
@@ -185,7 +181,6 @@ class PlayoffCalculator:
 
         Returns:
             The team with the highest total points
-
         """
         return max(all_teams, key=lambda x: (x.total, x.avg))
 
@@ -197,7 +192,6 @@ class PlayoffCalculator:
 
         Returns:
             Dictionary mapping conference names to their leader teams
-
         """
         conference_leaders: dict[str, PlayoffTeam] = {}
 
@@ -229,7 +223,6 @@ class PlayoffCalculator:
             playoff_teams: Dictionary of teams in playoffs
             presidents_trophy_team: Presidents' Trophy winner
             conference_leaders: Dictionary of conference leaders
-
         """
         for team in all_teams:
             team.status_indicator = self._get_status_indicator(
@@ -251,7 +244,6 @@ class PlayoffCalculator:
 
         Returns:
             Status indicator character
-
         """
         # Presidents' Trophy (most significant)
         if team.abbrev == presidents_trophy_team.abbrev:
@@ -281,7 +273,6 @@ class PlayoffCalculator:
 
         Returns:
             Dictionary mapping conference names to team lists
-
         """
         result: dict[str, list[PlayoffTeam]] = defaultdict(list)
 

--- a/src/nhl_scrabble/processors/team_processor.py
+++ b/src/nhl_scrabble/processors/team_processor.py
@@ -18,9 +18,8 @@ logger = logging.getLogger(__name__)
 class TeamProcessor:
     """Process team roster data and calculate aggregate scores.
 
-    This class orchestrates fetching roster data for all NHL teams,
-    calculating Scrabble scores for all players, and aggregating
-    statistics at team, division, and conference levels.
+    This class orchestrates fetching roster data for all NHL teams, calculating Scrabble scores for
+    all players, and aggregating statistics at team, division, and conference levels.
     """
 
     def __init__(self, api_client: NHLApiClient, scorer: ScrabbleScorer) -> None:
@@ -29,7 +28,6 @@ class TeamProcessor:
         Args:
             api_client: NHL API client for fetching data
             scorer: Scrabble scorer for calculating player scores
-
         """
         self.api_client = api_client
         self.scorer = scorer
@@ -52,7 +50,6 @@ class TeamProcessor:
             >>> teams, players, failed = processor.process_all_teams()
             >>> len(teams) > 0
             True
-
         """
         logger.info("Starting team processing")
 
@@ -110,7 +107,6 @@ class TeamProcessor:
 
         Returns:
             List of PlayerScore objects for all players on the team
-
         """
         team_players: list[PlayerScore] = []
 
@@ -147,7 +143,6 @@ class TeamProcessor:
             >>> standings = processor.calculate_division_standings(teams)
             >>> "Atlantic" in standings
             True
-
         """
         division_data: dict[str, dict[str, Any]] = defaultdict(
             lambda: {"total": 0, "teams": [], "player_count": 0}
@@ -189,7 +184,6 @@ class TeamProcessor:
             >>> standings = processor.calculate_conference_standings(teams)
             >>> "Eastern" in standings
             True
-
         """
         conference_data: dict[str, dict[str, Any]] = defaultdict(
             lambda: {"total": 0, "teams": [], "player_count": 0}

--- a/src/nhl_scrabble/reports/base.py
+++ b/src/nhl_scrabble/reports/base.py
@@ -7,8 +7,8 @@ from typing import Any
 class BaseReporter(ABC):
     """Abstract base class for all reporters.
 
-    All report generators should inherit from this class and implement
-    the generate() method to produce their specific output format.
+    All report generators should inherit from this class and implement the generate() method to
+    produce their specific output format.
     """
 
     @abstractmethod
@@ -20,7 +20,6 @@ class BaseReporter(ABC):
 
         Returns:
             Formatted report string
-
         """
 
     def _format_header(self, title: str, width: int = 80) -> str:
@@ -32,7 +31,6 @@ class BaseReporter(ABC):
 
         Returns:
             Formatted header string
-
         """
         separator = "=" * width
         return f"\n{separator}\n\n{title}\n{separator}"
@@ -46,7 +44,6 @@ class BaseReporter(ABC):
 
         Returns:
             Formatted subheader string
-
         """
         separator = "-" * width
         return f"\n{title}\n{separator}"

--- a/src/nhl_scrabble/reports/conference_report.py
+++ b/src/nhl_scrabble/reports/conference_report.py
@@ -15,7 +15,6 @@ class ConferenceReporter(BaseReporter):
 
         Returns:
             Formatted conference report string
-
         """
         output = self._format_header("🌎 CONFERENCE SCRABBLE SCORES")
 

--- a/src/nhl_scrabble/reports/division_report.py
+++ b/src/nhl_scrabble/reports/division_report.py
@@ -15,7 +15,6 @@ class DivisionReporter(BaseReporter):
 
         Returns:
             Formatted division report string
-
         """
         output = self._format_header("🗺️  DIVISION SCRABBLE SCORES")
 

--- a/src/nhl_scrabble/reports/playoff_report.py
+++ b/src/nhl_scrabble/reports/playoff_report.py
@@ -17,7 +17,6 @@ class PlayoffReporter(BaseReporter):
 
         Returns:
             Formatted playoff report string
-
         """
         output = self._format_header("🎰 WILD CARD PLAYOFF STANDINGS (Scrabble Edition)")
         output += "\nTop 3 from each division + 2 wild cards per conference"
@@ -72,7 +71,6 @@ class PlayoffReporter(BaseReporter):
 
         Returns:
             Dictionary mapping division names to team lists
-
         """
         teams_by_division: dict[str, list[PlayoffTeam]] = defaultdict(list)
         for team in teams:
@@ -93,7 +91,6 @@ class PlayoffReporter(BaseReporter):
 
         Returns:
             Formatted team line string
-
         """
         seed_part = f"{team.seed_type:20}" if show_seed else " " * 20
         return (

--- a/src/nhl_scrabble/reports/stats_report.py
+++ b/src/nhl_scrabble/reports/stats_report.py
@@ -15,7 +15,6 @@ class StatsReporter(BaseReporter):
 
         Args:
             top_players_count: Number of top players to show
-
         """
         self.top_players_count = top_players_count
 
@@ -34,7 +33,6 @@ class StatsReporter(BaseReporter):
 
         Returns:
             Formatted statistics report string
-
         """
         output = ""
 

--- a/src/nhl_scrabble/reports/team_report.py
+++ b/src/nhl_scrabble/reports/team_report.py
@@ -12,7 +12,6 @@ class TeamReporter(BaseReporter):
 
         Args:
             top_players_per_team: Number of top players to show per team
-
         """
         self.top_players_per_team = top_players_per_team
 
@@ -24,7 +23,6 @@ class TeamReporter(BaseReporter):
 
         Returns:
             Formatted team report string
-
         """
         output = self._format_header("📊 TEAM SCRABBLE SCORES (Sorted by Total Score)")
 

--- a/src/nhl_scrabble/scoring/scrabble.py
+++ b/src/nhl_scrabble/scoring/scrabble.py
@@ -67,7 +67,6 @@ class ScrabbleScorer:
             11
             >>> scorer.calculate_score("Ovechkin")
             22
-
         """
         return sum(self.LETTER_VALUES.get(char.upper(), 0) for char in name)
 
@@ -91,7 +90,6 @@ class ScrabbleScorer:
             >>> result = scorer.score_player(player, "EDM", "Pacific", "Western")
             >>> result.full_score
             32
-
         """
         first_name = player_data["firstName"]["default"]
         last_name = player_data["lastName"]["default"]

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
     yamllint
     flake8
     absolufy-imports
+    docformatter
     autopep8
     doc8
     rstcheck
@@ -228,6 +229,17 @@ commands_pre =
 commands =
     autopep8 --diff --recursive src tests {posargs}
 
+[testenv:docformatter]
+# Docstring formatting - format Python docstrings
+description = Format Python docstrings with docformatter
+labels = format, quality
+skip_install = true
+deps = docformatter
+commands_pre =
+    docformatter --version
+commands =
+    docformatter --diff --recursive --wrap-summaries 100 --wrap-descriptions 100 src tests {posargs}
+
 [testenv:doc8]
 # RST documentation linting - check reStructuredText files
 description = Lint RST documentation with doc8
@@ -342,6 +354,7 @@ deps =
     flake8
     flake8-pyproject
     absolufy-imports
+    docformatter
     autopep8
     doc8
     rstcheck
@@ -357,6 +370,7 @@ commands_pre =
     validate-pyproject --version
     yamllint --version
     flake8 --version
+    docformatter --version
     autopep8 --version
     doc8 --version
     rstcheck --version
@@ -373,6 +387,7 @@ commands =
     yamllint .
     flake8 src tests
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
+    docformatter --diff --recursive --wrap-summaries 100 --wrap-descriptions 100 src tests
     autopep8 --diff --recursive src tests
     doc8 docs
     rstcheck --recursive docs


### PR DESCRIPTION
## Summary

Add **docformatter** for comprehensive Python docstring formatting following PEP 257 standards.

## Changes

### Configuration
- **Pre-commit hook** (local): docformatter with `wrap-summaries=100`, `wrap-descriptions=100`
- **pyproject.toml**: Comprehensive docformatter configuration matching ruff's line-length=100
- **Tox environment**: `docformatter` with explicit wrap arguments
- **GitHub Actions**: Added to CI matrix for continuous validation

### Integration
- Disabled ruff's `docstring-code-format` to avoid formatter conflicts
- Added `D413` to ruff ignore list (conflicts with docformatter's blank line handling)
- Works alongside ruff-format: docformatter handles docstrings, ruff handles code

### Code Changes
- Reformatted all Python docstrings:
  - Removed trailing blank lines in docstrings
  - Wrapped long docstring descriptions to 100 characters
  - Maintained PEP 257 compliance with pragmatic settings

### Documentation
- Updated README.md: 42 → 43 hooks, added Docstring formatting category
- Updated CLAUDE.md: 42 → 43 hooks, added docformatter details
- Updated CHANGELOG.md: Added comprehensive docformatter integration entry

## Testing

✅ Pre-commit: All 43 hooks pass
✅ Tox: `tox -e docformatter` passes
✅ Make: `make tox-docformatter` passes

## Impact

Hook count: **42 → 43**  
Total pre-commit hooks: **43 comprehensive quality checks**