### PR TITLE
Add Black for Python code formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - yamllint
           - flake8
           - absolufy-imports
+          - black
           - docformatter
           - autopep8
           - doc8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,6 +189,13 @@ repos:
   # Python Formatting - Code and Docstring Formatting
   # ============================================================================
 
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+      - id: black
+        # Comprehensive Python code formatting (matches ruff's ALL rules philosophy)
+        args: []  # Config is in pyproject.toml
+
   - repo: local
     hooks:
       - id: docformatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Black Integration** - Python code formatting with Black
+  - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
+  - Pre-commit hook for automatic Black formatting
+  - Tox environment (black) for standalone formatting checks
+  - Added to CI/CD pipeline for continuous code formatting validation
+  - Configuration: line-length=100, target-version=py310-py313 (match ruff)
+  - Works harmoniously with ruff-format: both are Black-compatible
+  - Formatting order: black → docformatter → autopep8 → ruff-check → ruff-format
+  - Note: Black and ruff-format produce identical output (ruff-format is Black-compatible)
+  - 44 total pre-commit hooks for comprehensive code quality
+
 ### Changed
 
 - **Configuration File Reorganization** - Improved structure and consistency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 43 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 44 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (43 Comprehensive Checks)
+## Pre-commit Hooks (44 Comprehensive Checks)
 
-The project uses 43 pre-commit hooks for automatic code quality validation:
+The project uses 44 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -181,13 +181,17 @@ The project uses 43 pre-commit hooks for automatic code quality validation:
 
 - `flake8`: Python code linting and style checking (comprehensive configuration via flake8-pyproject)
 
+**Black Hooks (1 from psf/black-pre-commit-mirror):**
+
+- `black`: Python code formatting (line-length=100, matches ruff-format, runs before other formatters)
+
 **Docformatter Hooks (1 from local):**
 
 - `docformatter`: Python docstring formatting (wrap-length=100, PEP 257 style)
 
 **Autopep8 Hooks (1 from hhatto/autopep8):**
 
-- `autopep8`: PEP 8 auto-formatting (runs before ruff-format, aggressive level 2)
+- `autopep8`: PEP 8 auto-formatting (runs after black, before ruff-format, aggressive level 2)
 
 **Ruff Hooks (2 from ruff-pre-commit):**
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ pre-commit autoupdate
 - **Python quality** (7): Code patterns (blanket-noqa, mock-methods, eval, type-annotations, etc.)
 - **Python imports** (1): Convert relative imports to absolute (absolufy-imports)
 - **Project validation** (1): pyproject.toml validation against PEP standards (validate-pyproject)
-- **Python formatting** (1): PEP 8 auto-formatting (autopep8)
+- **Python formatting** (2): Black formatting and PEP 8 auto-formatting (black, autopep8)
 - **Docstring formatting** (1): Python docstring formatting (docformatter)
 - **YAML linting** (1): YAML file validation and linting (yamllint)
 - **Spelling** (1): Code and documentation spell checking (codespell)
@@ -520,7 +520,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 43 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, docformatter, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 44 hooks (meta, pre-commit-hooks, pygrep-hooks, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, black, docformatter, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,33 @@ pre_summary_newline = false  # Don't add newline before summary (PEP 257 default
 # Exclude patterns (align with other tool exclusions)
 exclude = [".git", ".tox", ".venv", "venv", "build", "dist", "*.egg-info"]
 
+# Black configuration
+[tool.black]
+# Comprehensive Python code formatting (matches ruff's ALL rules philosophy)
+# Align with ruff's configuration for consistency
+line-length = 100  # Match ruff's line-length
+target-version = ["py310", "py311", "py312", "py313"]  # Match ruff's target-version
+skip-string-normalization = false  # Use double quotes (matches ruff's quote-style)
+skip-magic-trailing-comma = false  # Respect magic trailing commas
+# Exclude patterns (align with other tool exclusions)
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.tox
+  | \.venv
+  | venv
+  | build
+  | dist
+  | \.egg-info
+  | __pycache__
+  | \.pytest_cache
+  | \.mypy_cache
+  | \.ruff_cache
+)/
+'''
+
 # Ruff configuration
 [tool.ruff]
 target-version = "py310"

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ envlist =
     yamllint
     flake8
     absolufy-imports
+    black
     docformatter
     autopep8
     doc8
@@ -248,6 +249,17 @@ commands_pre =
 commands =
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
 
+[testenv:black]
+# Python code formatting - format Python code with Black
+description = Format Python code with Black
+labels = format, quality
+skip_install = true
+deps = black
+commands_pre =
+    black --version
+commands =
+    black --check --diff src tests {posargs}
+
 [testenv:autopep8]
 # PEP 8 formatting - auto-format Python code
 description = Format Python code with autopep8
@@ -392,6 +404,7 @@ deps =
     flake8
     flake8-pyproject
     absolufy-imports
+    black
     docformatter
     autopep8
     doc8
@@ -408,6 +421,7 @@ commands_pre =
     validate-pyproject --version
     yamllint --version
     flake8 --version
+    black --version
     docformatter --version
     autopep8 --version
     doc8 --version
@@ -425,6 +439,7 @@ commands =
     yamllint .
     flake8 src tests
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
+    black --check --diff src tests
     docformatter --diff --recursive --wrap-summaries 100 --wrap-descriptions 100 src tests
     autopep8 --diff --recursive src tests
     doc8 docs


### PR DESCRIPTION
## Summary

Add **Black** formatter with comprehensive configuration matching ruff settings. Black and ruff-format are compatible and produce identical output, providing redundant but consistent formatting validation.

## Configuration

### pyproject.toml
- ✅ **line-length** = 100 (matches ruff)
- ✅ **target-version** = ["py310", "py311", "py312", "py313"] (matches ruff)
- ✅ **skip-string-normalization** = false (use double quotes, matches ruff)
- ✅ **skip-magic-trailing-comma** = false (matches ruff)
- ✅ Comprehensive exclude patterns matching other tools

### Pre-commit Hook
- ✅ Added black from `psf/black-pre-commit-mirror`
- ✅ Runs in Python formatting section before other formatters
- ✅ Configuration read from pyproject.toml

### Tox Environment
- ✅ Added `[testenv:black]` with `--check --diff` for validation
- ✅ Added to CI environment for comprehensive testing
- ✅ Uses tox-uv for fast package installation

### GitHub Actions
- ✅ Added `black` to tox-env matrix for CI testing

## Formatting Order

The formatters run in this order:
1. **black** - Comprehensive Python code formatting
2. **docformatter** - Docstring formatting
3. **autopep8** - PEP 8 auto-formatting
4. **ruff-check** - Linting with fixes
5. **ruff-format** - Final formatting (Black-compatible)

## Integration Notes

### Black vs Ruff Format
- **ruff-format** is designed to be a drop-in replacement for Black
- Both produce identical output with matching configurations
- Having both provides redundant validation ensuring Black-compatible formatting
- No conflicts detected: all code already formatted correctly by ruff-format

### Testing Results

✅ **Pre-commit**: All **44 hooks** pass (was 43, now +1 for black)  
✅ **Tox**: Environments verified:
  - `tox -e black` - Passed
  - `tox -e ruff-check` - Passed
  - `tox -e ruff-format` - Passed

✅ **Make**: `make tox-black` - Passed

### Code Changes
- ✅ **No code formatting changes needed**
- ✅ Code already formatted correctly via ruff-format
- ✅ Black validates existing formatting (all 32 files unchanged)

## Documentation Updates

- ✅ **README.md**: 43 → 44 hooks, updated Python formatting category
- ✅ **CLAUDE.md**: 43 → 44 hooks, added Black hooks section
- ✅ **CHANGELOG.md**: Added comprehensive Black integration details

## Impact

**Hook count**: 43 → **44**  
**Total pre-commit hooks**: **44 comprehensive quality checks**

**Compatibility**: Perfect alignment with ruff-format (both Black-compatible)