### PR TITLE
Add autoflake for unused import and variable removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           - flake8
           - isort
           - absolufy-imports
+          - autoflake
           - black
           - docformatter
           - autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -196,6 +196,21 @@ repos:
   # Python Formatting - Code and Docstring Formatting
   # ============================================================================
 
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.3.1
+    hooks:
+      - id: autoflake
+        # Comprehensive unused import/variable removal (matches ruff's ALL rules philosophy)
+        # Aligns with ruff's F401 (unused imports) and F841 (unused variables) rules
+        args:
+          [
+            --in-place,
+            --remove-all-unused-imports,
+            --remove-unused-variables,
+            --remove-duplicate-keys,
+            --ignore-init-module-imports,
+          ]
+
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.10.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Autoflake Integration** - Unused import and variable removal
+
+  - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
+  - Pre-commit hook for automatic unused code removal
+  - Tox environment (autoflake) for standalone unused code checks
+  - Added to CI/CD pipeline for continuous code cleanliness validation
+  - Configuration: remove-all-unused-imports, remove-unused-variables, remove-duplicate-keys
+  - Aligns with ruff's F401 (unused imports) and F841 (unused variables) rules
+  - Ignores __init__.py imports (matches ruff's per-file-ignores for re-exports)
+  - Works harmoniously with ruff's unused import/variable detection
+  - 46 total pre-commit hooks for comprehensive code quality
+
 - **Isort Integration** - Python import sorting
 
   - Comprehensive configuration in pyproject.toml matching ruff's ALL rules philosophy
@@ -19,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Works harmoniously with ruff's isort rules (I001-I005)
   - Import ordering: FUTURE → STDLIB → THIRDPARTY <!-- codespell:ignore --> → FIRSTPARTY → LOCALFOLDER
   - Code changes: Collapsed multi-line imports to single line where they fit in 100 chars
-  - 45 total pre-commit hooks for comprehensive code quality
+  - 45 total pre-commit hooks (before autoflake addition)
 
 - **Black Integration** - Python code formatting with Black
 
@@ -31,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Works harmoniously with ruff-format: both are Black-compatible
   - Formatting order: black → docformatter → autopep8 → ruff-check → ruff-format
   - Note: Black and ruff-format produce identical output (ruff-format is Black-compatible)
-  - 44 total pre-commit hooks for comprehensive code quality
+  - 44 total pre-commit hooks (before isort and autoflake additions)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 45 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 46 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (45 Comprehensive Checks)
+## Pre-commit Hooks (46 Comprehensive Checks)
 
-The project uses 45 pre-commit hooks for automatic code quality validation:
+The project uses 46 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -181,6 +181,10 @@ The project uses 45 pre-commit hooks for automatic code quality validation:
 **Flake8 Hooks (1 from pycqa/flake8):**
 
 - `flake8`: Python code linting and style checking (comprehensive configuration via flake8-pyproject)
+
+**Autoflake Hooks (1 from PyCQA/autoflake):**
+
+- `autoflake`: Remove unused imports and variables (aligns with ruff's F401 and F841 rules, ignores __init__.py imports)
 
 **Black Hooks (1 from psf/black-pre-commit-mirror):**
 

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 45 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, black, docformatter, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 46 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, black, docformatter, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,19 @@ exclude = [
     ".ruff_cache",
 ]
 
+# Autoflake configuration
+[tool.autoflake]
+# Comprehensive unused import/variable removal (matches ruff's ALL rules philosophy)
+# Align with ruff's F401 (unused imports) and F841 (unused variables) rules
+check = true  # Check only mode (no changes) - use --check in pre-commit/tox
+in-place = false  # Don't modify files in place (safer default)
+remove-all-unused-imports = true  # Remove all unused imports (matches ruff F401)
+remove-unused-variables = true  # Remove unused variables (matches ruff F841)
+remove-duplicate-keys = true  # Remove duplicate keys in dictionaries
+ignore-init-module-imports = true  # Don't remove imports from __init__.py (matches ruff's per-file-ignores)
+# Exclude patterns (align with other tool exclusions)
+exclude = [".git", ".tox", ".venv", "venv", "build", "dist", "*.egg-info", "__pycache__"]
+
 # Autopep8 configuration
 [tool.autopep8]
 # Comprehensive PEP 8 formatting (matches ruff's ALL rules philosophy as closely as possible)

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ envlist =
     flake8
     isort
     absolufy-imports
+    autoflake
     black
     docformatter
     autopep8
@@ -260,6 +261,17 @@ deps = absolufy-imports
 commands_pre =
 commands =
     bash -c 'absolufy-imports --application-directories=src src/**/*.py'
+
+[testenv:autoflake]
+# Remove unused imports and variables
+description = Remove unused imports and variables with autoflake
+labels = format, quality
+skip_install = true
+deps = autoflake
+commands_pre =
+    autoflake --version
+commands =
+    autoflake --check --recursive --remove-all-unused-imports --remove-unused-variables --remove-duplicate-keys --ignore-init-module-imports src tests {posargs}
 
 [testenv:black]
 # Python code formatting - format Python code with Black


### PR DESCRIPTION
## Summary

Integrate autoflake as an additional code quality tool that complements ruff's built-in unused import (F401) and unused variable (F841) detection. Both tools use similar configuration and produce consistent results, providing redundant validation of code cleanliness.

## Changes

### Configuration Files
- **pyproject.toml**: Added `[tool.autoflake]` configuration matching ruff's F401/F841 rules
  - Remove all unused imports (matches ruff F401)
  - Remove unused variables (matches ruff F841)
  - Remove duplicate keys in dictionaries
  - Ignore __init__.py imports (matches ruff's per-file-ignores for re-exports)
  - Exclude standard directories (align with other tool exclusions)
- **.pre-commit-config.yaml**: Added autoflake hook (v2.3.1) before black
- **tox.ini**: Added autoflake environment for standalone testing
- **.github/workflows/ci.yml**: Added autoflake to tox matrix

### Documentation
- **README.md**: Updated to reflect 46 pre-commit hooks (was 45)
- **CLAUDE.md**: Updated to reflect 46 pre-commit hooks with autoflake details
- **CHANGELOG.md**: Added comprehensive autoflake integration entry

## Testing

All quality checks pass:
- ✅ All 46 pre-commit hooks pass
- ✅ `tox -e autoflake` passes
- ✅ `make tox-autoflake` passes
- ✅ `make check` passes (all quality checks + tests)
- ✅ No conflicts with ruff's F401/F841 rules
- ✅ All existing tests continue to pass

## Dual Validation

This provides dual validation of code cleanliness:
1. **ruff check** (with F401/F841 rules)
2. **autoflake standalone**
3. Both run in pre-commit, tox, and CI

This redundant checking ensures unused imports and variables are caught and removed consistently across the entire codebase.

## CI Pipeline

The CI pipeline will now run 26 checks:
- 4 Python version tests (3.10, 3.11, 3.12, 3.13)
- 21 tox environments (including new autoflake environment)
- 1 pre-commit check (46 hooks including new autoflake hook)

All checks are expected to pass.