### PR TITLE
Add pyroma package metadata quality checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           - codespell
           - pymarkdown
           - mdformat
+          - pyroma
           - validate-pyproject
           - tox-ini-fmt
           - yamllint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,9 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Install docformatter for pre-commit
+      - name: Install docformatter and pyroma for pre-commit
         run: |
-          uv pip install docformatter --system
+          uv pip install docformatter pyroma --system
 
       - name: Run pre-commit with UV
         uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,6 +110,18 @@ repos:
         # Comprehensive validation (matches ruff's ALL rules philosophy)
         args: []  # Config is in pyproject.toml
 
+  - repo: local
+    hooks:
+      - id: pyroma
+        name: pyroma
+        # Comprehensive Python package metadata quality check (matches ruff's ALL rules philosophy)
+        description: Rate the quality of Python package metadata
+        entry: pyroma
+        args: ['.']
+        language: system
+        pass_filenames: false
+        files: pyproject.toml
+
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 1.5.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pyroma Integration** - Python package metadata quality rating
+
+  - Quality checker for Python package metadata and project setup
+  - Pre-commit hook (local) for automatic metadata quality checks
+  - Tox environment (pyroma) for standalone quality rating
+  - Added to CI/CD pipeline for continuous metadata quality validation
+  - Rates project metadata on a 10-point scale
+  - Checks: package name, version, description, classifiers, license, readme, keywords, author info
+  - Current project rating: 10/10 ("Your cheese is so fresh most people think it's a cream: Mascarpone")
+  - Works harmoniously with validate-pyproject for comprehensive metadata validation
+  - 48 total pre-commit hooks for comprehensive code quality
+
 - **Tox-ini-fmt Integration** - Tox configuration file formatting
 
   - Formatter for tox.ini files enforcing tox 4 best practices
@@ -20,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removes deprecated fields (minversion, isolated_build now defaults)
   - Updates minimum version requirements (tox>=4.2, tox-uv>=1)
   - Works harmoniously with tox 4 and tox-uv for consistent configuration
-  - 47 total pre-commit hooks for comprehensive code quality
+  - 47 total pre-commit hooks (before pyroma addition)
 
 - **Autoflake Integration** - Unused import and variable removal
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 47 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 48 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (47 Comprehensive Checks)
+## Pre-commit Hooks (48 Comprehensive Checks)
 
-The project uses 47 pre-commit hooks for automatic code quality validation:
+The project uses 48 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -152,9 +152,10 @@ The project uses 47 pre-commit hooks for automatic code quality validation:
 - `isort`: Sort Python imports (Black-compatible, line-length=100, matches ruff's isort configuration)
 - `absolufy-imports`: Convert relative imports to absolute imports (comprehensive by default)
 
-**Project Validation Hooks (2 from validate-pyproject and tox-ini-fmt):**
+**Project Validation Hooks (3 from validate-pyproject, pyroma, and tox-ini-fmt):**
 
 - `validate-pyproject`: Validates pyproject.toml against PEP 517, 518, 621, 631 standards
+- `pyroma`: Rates Python package metadata quality (checks descriptions, classifiers, documentation, etc.)
 - `tox-ini-fmt`: Formats tox.ini to standard structure (enforces tox 4 best practices, auto-formats configuration)
 
 **YAML Linting Hooks (1 from yamllint):**

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 47 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, black, docformatter, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 48 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, absolufy-imports, validate-pyproject, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, black, docformatter, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ env_list =
     codespell
     pymarkdown
     mdformat
+    pyroma
     validate-pyproject
     tox-ini-fmt
     yamllint
@@ -162,6 +163,16 @@ commands =
     bash -c 'mdformat --check *.md docs'
 allowlist_externals =
     bash
+labels = quality
+
+[testenv:pyroma]
+description = Rate Python package metadata quality
+skip_install = true
+deps =
+    pyroma
+commands_pre =
+commands =
+    pyroma {posargs:.}
 labels = quality
 
 [testenv:validate-pyproject]


### PR DESCRIPTION
## Summary

Add comprehensive package metadata quality rating with pyroma:

- **Pre-commit hook**: Added as local hook (no official repo available)
- **Tox environment**: `tox -e pyroma` for testing
- **CI integration**: Added to GitHub Actions matrix
- **Documentation**: Updated to reflect 48 total hooks

## Current Rating

**10/10** - "Your cheese is so fresh most people think it's a cream: Mascarpone"

All package metadata quality checks pass.

## Testing

✅ Pre-commit: All 48 hooks pass  
✅ Tox: `tox -e pyroma` passes  
✅ Make: `make tox-pyroma` passes  
✅ Combined: `tox -e ruff-check,mypy,pyroma` all pass

## Configuration Philosophy

Follows project's "comprehensive by default" approach, matching ruff's ALL rules philosophy. Pyroma requires no configuration - it rates entire package metadata against Python packaging best practices.

## Test plan

- [ ] CI: 4 Python version tests pass
- [ ] CI: 24 tox environment tests pass (including new pyroma)
- [ ] CI: Pre-commit checks pass
- [ ] Total: 29 checks expected