### PR TITLE
Add unimport for comprehensive unused import checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           - isort
           - interrogate
           - deptry
+          - unimport
           - absolufy-imports
           - autoflake
           - black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # ============================================================================
 # NHL Scrabble - Pre-commit Hooks Configuration
 # ============================================================================
-# 50 comprehensive hooks for code quality, security, and consistency
+# 51 comprehensive hooks for code quality, security, and consistency
 # Organized by category for maintainability
 # Matches ruff's ALL rules philosophy: comprehensive by default with selective ignores
 
@@ -206,6 +206,14 @@ repos:
         # Comprehensive dependency checker (matches ruff's ALL rules philosophy)
         # Detects: obsolete, missing, transitive, and misplaced dev dependencies
         args: [src]  # Additional config in pyproject.toml
+
+  - repo: https://github.com/hakancelikdev/unimport
+    rev: 1.3.1
+    hooks:
+      - id: unimport
+        # Comprehensive unused import checker (matches ruff's ALL rules philosophy)
+        # Finds and reports unused import statements
+        args: [--check, --diff]  # Additional config in pyproject.toml
 
   # ============================================================================
   # UV - Dependency Lock File Validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Unimport Integration** - Unused import checker
+
+  - Comprehensive unused import checker matching ruff's ALL rules philosophy
+  - Pre-commit hook (hakancelikdev/unimport) for automatic unused import detection
+  - Tox environment (unimport) for standalone unused import checks
+  - Added to CI/CD pipeline for continuous import hygiene validation
+  - Configuration in pyproject.toml with comprehensive checking
+  - Detects and reports unused import statements across the codebase
+  - Ignores __init__.py files (matches ruff's per-file-ignores for __init__.py F401)
+  - Excludes build/test artifacts using gitignore patterns
+  - Works harmoniously with autoflake and ruff's unused import detection (F401)
+  - Current project status: no unused imports found (clean codebase)
+  - 51 total pre-commit hooks for comprehensive code quality
+
 - **Deptry Integration** - Python dependency checker
 
   - Comprehensive dependency checker matching ruff's ALL rules philosophy
@@ -22,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive by default: no ignores, checks all dependency issues
   - Validation identified and removed unused pydantic dependency from main dependencies
   - Works harmoniously with pip-audit for comprehensive dependency management
-  - 50 total pre-commit hooks for comprehensive code quality
+  - 50 total pre-commit hooks (before unimport addition)
 
 - **Interrogate Integration** - Python docstring coverage checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 50 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 51 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -787,7 +787,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 50 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown, documentation, UV, flake8, autoflake, black, docformatter, autopep8, ruff, mypy, interrogate, deptry)
+- **Pre-commit Hooks:** 51 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown, documentation, UV, flake8, autoflake, black, docformatter, autopep8, ruff, mypy, interrogate, deptry, unimport)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (50 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (51 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -520,7 +520,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 50 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, interrogate, deptry, absolufy-imports, validate-pyproject, pyroma, tox-ini-fmt, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autoflake, black, docformatter, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 51 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, interrogate, deptry, unimport, absolufy-imports, validate-pyproject, pyroma, tox-ini-fmt, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autoflake, black, docformatter, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -806,3 +806,22 @@ ignore = []  # Empty list means check everything
 [tool.deptry.package_module_name_map]
 # Package name -> module name mapping for packages where they differ
 python-dotenv = "dotenv"  # python-dotenv package provides 'dotenv' module
+
+# ============================================================================
+# Unimport - Unused Import Checker
+# ============================================================================
+
+[tool.unimport]
+# Comprehensive unused import checking (matches ruff's ALL rules philosophy)
+
+# File patterns to exclude from scanning (regex pattern)
+exclude = "\\.git|\\.tox|\\.venv|venv|build|dist|.*\\.egg-info|__pycache__"
+
+# Ignore __init__.py files (they often have intentional re-exports)
+ignore_init = true  # Match ruff's per-file-ignores for __init__.py F401
+
+# Include star imports in scanning (comprehensive checking)
+include_star_import = false  # Star imports are already flagged by ruff (F403/F405)
+
+# Use gitignore patterns
+gitignore = true  # Respect .gitignore patterns

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ env_list =
     isort
     interrogate
     deptry
+    unimport
     absolufy-imports
     autoflake
     black
@@ -240,6 +241,17 @@ commands_pre =
     deptry --version
 commands =
     deptry {posargs:src}
+labels = quality
+
+[testenv:unimport]
+description = Check for unused imports with unimport
+skip_install = true
+deps =
+    unimport
+commands_pre =
+    unimport --version
+commands =
+    unimport --check --diff {posargs:src}
 labels = quality
 
 [testenv:absolufy-imports]


### PR DESCRIPTION
## Summary

Add comprehensive unused import detection with unimport:

- **Pre-commit hook**: Automatic unused import checks
- **Tox environment**: `tox -e unimport` for standalone validation
- **CI integration**: Added to GitHub Actions matrix
- **Documentation**: Updated to reflect 51 total hooks

## Unused Import Detection

Unimport finds and reports:
- Unused import statements
- Unused imported names
- Duplicate imports

## Current Status

✅ **Clean codebase** - No unused imports found in the project

All imports are properly used, demonstrating good code hygiene.

## Configuration Philosophy

Follows project's "comprehensive by default" approach, matching ruff's ALL rules philosophy:

- **Comprehensive checking**: Scans all Python files for unused imports
- **Ignore __init__.py**: Matches ruff's per-file-ignores for __init__.py F401 (re-exports)
- **Gitignore patterns**: Respects .gitignore for file exclusion
- **Excludes artifacts**: Build/test directories excluded (.git, .tox, .venv, build, dist)
- **No star imports**: Star imports excluded (already handled by ruff F403/F405)

## Testing

✅ Pre-commit: All 51 hooks pass  
✅ Tox: `tox -e unimport` passes - no unused imports  
✅ Make: `make tox-unimport` passes  
✅ Combined: `tox -e ruff-check,mypy,deptry,unimport` all pass  
✅ Full check: `make check` passes (format, lint, type, tests)

## Configuration Details

**pyproject.toml:**
```toml
[tool.unimport]
exclude = "\\.git|\\.tox|\\.venv|venv|build|dist|.*\\.egg-info|__pycache__"
ignore_init = true  # Match ruff's per-file-ignores for __init__.py F401
include_star_import = false  # Star imports already flagged by ruff (F403/F405)
gitignore = true  # Respect .gitignore patterns
```

## Harmony with Existing Tools

Works alongside:
- **autoflake**: Removes unused imports (unimport only reports)
- **ruff F401**: Checks for unused imports (unimport provides additional validation)
- **isort**: Organizes imports (unimport validates import usage)

## Test plan

- [ ] CI: 4 Python version tests pass
- [ ] CI: 27 tox environment tests pass (including new unimport)
- [ ] CI: Pre-commit checks pass (51 hooks)
- [ ] Total: 32 checks expected