### PR TITLE
Add pydocstyle for comprehensive docstring style checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           - interrogate
           - deptry
           - unimport
+          - pydocstyle
           - absolufy-imports
           - autoflake
           - black
@@ -126,9 +127,9 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Install docformatter, pyroma, and deptry for pre-commit
+      - name: Install docformatter, pyroma, deptry, and pydocstyle for pre-commit
         run: |
-          uv pip install docformatter pyroma deptry --system
+          uv pip install docformatter pyroma deptry pydocstyle --system
 
       - name: Run pre-commit with UV
         uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # ============================================================================
 # NHL Scrabble - Pre-commit Hooks Configuration
 # ============================================================================
-# 51 comprehensive hooks for code quality, security, and consistency
+# 52 comprehensive hooks for code quality, security, and consistency
 # Organized by category for maintainability
 # Matches ruff's ALL rules philosophy: comprehensive by default with selective ignores
 
@@ -198,6 +198,15 @@ repos:
         # Requires 100% docstring coverage for all Python code
         args: []  # Config is in pyproject.toml
         pass_filenames: false  # Check entire project for coverage percentage
+
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        # Comprehensive docstring style checking (matches ruff's ALL rules philosophy)
+        # Checks docstring format and style per PEP 257
+        args: []  # Config is in pyproject.toml
+        additional_dependencies: [tomli]  # Required to read pyproject.toml
 
   - repo: https://github.com/fpgmaas/deptry
     rev: 0.25.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pydocstyle Integration** - Python docstring style checker
+
+  - Comprehensive docstring style checker matching ruff's ALL rules philosophy
+  - Pre-commit hook (PyCQA/pydocstyle) for automatic docstring style validation
+  - Tox environment (pydocstyle) for standalone docstring style checks
+  - Added to CI/CD pipeline for continuous docstring style validation
+  - Configuration in pyproject.toml following PEP 257 convention
+  - Checks docstring format and style for all Python code
+  - Aligned ignore list (add-ignore) with ruff's D-rule ignores for consistency
+  - Ignores: D100-D107 (handled by interrogate), D203/D213 (conflicting formatting), D413 (conflicts with docformatter)
+  - Works harmoniously with interrogate (coverage) and docformatter (formatting)
+  - Current project status: no docstring style violations (clean docstrings)
+  - 52 total pre-commit hooks for comprehensive code quality
+
 - **Unimport Integration** - Unused import checker
 
   - Comprehensive unused import checker matching ruff's ALL rules philosophy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ NHL Scrabble Score Analyzer is a professional Python package that fetches curren
 **Current Version:** 2.0.0
 **Python:** 3.10-3.13
 **License:** MIT
-**Pre-commit Hooks:** 51 hooks (comprehensive quality checks)
+**Pre-commit Hooks:** 52 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
 
 ## Quick Start
@@ -116,9 +116,9 @@ nhl-scrabble/
 - --format (text/json), --output, --verbose
 - Environment variable support
 
-## Pre-commit Hooks (48 Comprehensive Checks)
+## Pre-commit Hooks (52 Comprehensive Checks)
 
-The project uses 48 pre-commit hooks for automatic code quality validation:
+The project uses 52 pre-commit hooks for automatic code quality validation:
 
 ### Hook Categories
 
@@ -175,6 +175,13 @@ The project uses 48 pre-commit hooks for automatic code quality validation:
 
 - `doc8`: RST style linting (comprehensive by default, max-line-length=100)
 - `rstcheck`: RST syntax checking (report_level=INFO, validates code blocks with Sphinx)
+
+**Documentation Quality Hooks (4 from interrogate, deptry, unimport, and pydocstyle):**
+
+- `interrogate`: Docstring coverage checking (requires 100% docstring coverage for all Python code)
+- `deptry`: Comprehensive dependency checker (detects obsolete, missing, transitive, and misplaced dev dependencies)
+- `unimport`: Unused import checker (finds and reports unused import statements)
+- `pydocstyle`: Docstring style checking (checks docstring format and style per PEP 257)
 
 **UV Hook (1 from uv-pre-commit):**
 
@@ -787,7 +794,7 @@ The project uses UV automatically via tox-uv:
 - **Modules:** 15 core modules
 - **Tests:** 36 tests (100% passing)
 - **Makefile Targets:** 55 documented targets (16 logical groupings)
-- **Pre-commit Hooks:** 51 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown, documentation, UV, flake8, autoflake, black, docformatter, autopep8, ruff, mypy, interrogate, deptry, unimport)
+- **Pre-commit Hooks:** 52 hooks (meta, file quality, Python quality, Python imports, project validation, YAML linting, spelling, markdown, documentation, UV, flake8, autoflake, black, docformatter, autopep8, ruff, mypy, interrogate, deptry, unimport, pydocstyle)
 - **Dependency Lock:** uv.lock with 1,957 lines
 - **Documentation:** 12 comprehensive guides
 - **CI/CD:** GitHub Actions with UV optimization

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ make uv-pip ARGS="list"
 
 ### Pre-commit Hooks
 
-The project uses comprehensive pre-commit hooks (51 total) for automatic code quality checks:
+The project uses comprehensive pre-commit hooks (52 total) for automatic code quality checks:
 
 ```bash
 # Install pre-commit hooks (one-time setup)
@@ -520,7 +520,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 - **Python Modules**: 15 core modules
 - **Tests**: 36 tests (100% passing)
 - **Makefile Targets**: 55 documented targets
-- **Pre-commit Hooks**: 51 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, interrogate, deptry, unimport, absolufy-imports, validate-pyproject, pyroma, tox-ini-fmt, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autoflake, black, docformatter, autopep8, ruff, mypy)
+- **Pre-commit Hooks**: 52 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, interrogate, deptry, unimport, pydocstyle, absolufy-imports, validate-pyproject, pyroma, tox-ini-fmt, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autoflake, black, docformatter, autopep8, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
 - **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -825,3 +825,30 @@ include_star_import = false  # Star imports are already flagged by ruff (F403/F4
 
 # Use gitignore patterns
 gitignore = true  # Respect .gitignore patterns
+
+# ============================================================================
+# Pydocstyle - Docstring Style Checker
+# ============================================================================
+
+[tool.pydocstyle]
+# Comprehensive docstring style checking (matches ruff's ALL rules philosophy)
+convention = "pep257"  # PEP 257 convention (comprehensive)
+
+# Match patterns for files to check
+match = ".*\\.py"  # Check all .py files
+match_dir = "[^\\.].*"  # Check all non-hidden directories
+
+# Additional error codes to ignore on top of convention (align with ruff's D ignores)
+add-ignore = [
+    "D100",  # Missing docstring in public module (checked by interrogate)
+    "D101",  # Missing docstring in public class (checked by interrogate)
+    "D102",  # Missing docstring in public method (checked by interrogate)
+    "D103",  # Missing docstring in public function (checked by interrogate)
+    "D104",  # Missing docstring in public package (checked by interrogate)
+    "D105",  # Missing docstring in magic method (checked by interrogate)
+    "D106",  # Missing docstring in public nested class (checked by interrogate)
+    "D107",  # Missing docstring in __init__ (checked by interrogate)
+    "D203",  # 1 blank line required before class docstring (conflicts with D211)
+    "D213",  # Multi-line docstring summary should start at second line (conflicts with D212)
+    "D413",  # Missing blank line after last section (conflicts with docformatter)
+]

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ env_list =
     interrogate
     deptry
     unimport
+    pydocstyle
     absolufy-imports
     autoflake
     black
@@ -253,6 +254,18 @@ commands_pre =
 commands =
     unimport --check --diff {posargs:src}
 labels = quality
+
+[testenv:pydocstyle]
+description = Check docstring style with pydocstyle
+skip_install = true
+deps =
+    pydocstyle
+    tomli
+commands_pre =
+    pydocstyle --version
+commands =
+    pydocstyle {posargs:src}
+labels = quality, docs
 
 [testenv:absolufy-imports]
 description = Convert relative imports to absolute imports


### PR DESCRIPTION
## Summary

Implements comprehensive PEP 257 docstring style validation with pydocstyle integration across pre-commit, tox, and CI/CD pipeline.

### Changes

**Configuration (pyproject.toml):**
- PEP 257 convention for comprehensive docstring style checking
- Aligned ignore list with ruff's D-rule ignores
- D100-D107: Checked by interrogate (coverage)
- D203, D213: Conflicting formatting rules
- D413: Conflicts with docformatter

**Pre-commit Integration (.pre-commit-config.yaml):**
- PyCQA/pydocstyle v6.3.0 hook
- Uses tomli for pyproject.toml reading
- Updates total hooks: 51 → 52

**Tox Integration (tox.ini):**
- [testenv:pydocstyle] environment
- Accessible via `make tox-pydocstyle`

**CI/CD Integration (.github/workflows/ci.yml):**
- Added to tox matrix
- Added to pre-commit installation step

**Documentation:**
- Updated hook counts across all documentation
- Added comprehensive CHANGELOG entry

### Testing

✅ Pre-commit: All 52 hooks passing
✅ Tox: `tox -e pydocstyle` passing
✅ Makefile: `make tox-pydocstyle` passing
✅ Project status: No docstring style violations

### Integration

Works harmoniously with:
- **interrogate**: Docstring coverage (100% required)
- **docformatter**: Docstring formatting
- **ruff**: D-rules for additional docstring checks

## Test plan

- [x] Pre-commit hooks passing locally
- [x] Tox environment tested
- [x] Makefile target tested
- [ ] CI pipeline (32 checks expected)