### PR TITLE
fix(ci): add CI detection to branch protection hook

### DIFF
--- a/.git-hooks/check-branch-protection.sh
+++ b/.git-hooks/check-branch-protection.sh
@@ -6,7 +6,32 @@ set -e
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 PROTECTED_BRANCHES="^(main|master)$"
 
+# Check if running in CI environment
+is_ci() {
+    # GitHub Actions
+    [[ -n "${GITHUB_ACTIONS}" ]] && return 0
+    # GitLab CI
+    [[ -n "${GITLAB_CI}" ]] && return 0
+    # Travis CI
+    [[ -n "${TRAVIS}" ]] && return 0
+    # CircleCI
+    [[ -n "${CIRCLECI}" ]] && return 0
+    # Jenkins
+    [[ -n "${JENKINS_URL}" ]] && return 0
+    # Generic CI indicator
+    [[ -n "${CI}" ]] && return 0
+
+    return 1
+}
+
 if [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]; then
+    # In CI: Allow the commit (it's already on main after PR merge)
+    if is_ci; then
+        echo "ℹ️  CI environment detected: Allowing commit to '$BRANCH' branch"
+        exit 0
+    fi
+
+    # Local: Warn and prompt for confirmation
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "⚠️  WARNING: You are committing directly to the '$BRANCH' branch!"

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -10,12 +10,41 @@ A pre-commit hook warns when committing directly to `main` or `master`:
 
 **Location:** `.git-hooks/check-branch-protection.sh`
 **Integration:** Added to `.pre-commit-config.yaml` as local hook
+
 **Behavior:**
+
+**In Local Development:**
 
 - Warns when committing to protected branches
 - Prompts for confirmation (Y/N)
 - Provides instructions for proper workflow
 - Can be bypassed with explicit confirmation
+
+**In CI Environments:**
+
+- Automatically detects CI environment
+- Allows commits to main without prompting
+- Logs informational message
+- Enables CI to run on main branch after PR merges
+
+**CI Detection:**
+
+The hook automatically detects the following CI environments:
+
+- GitHub Actions (`GITHUB_ACTIONS`)
+- GitLab CI (`GITLAB_CI`)
+- Travis CI (`TRAVIS`)
+- CircleCI (`CIRCLECI`)
+- Jenkins (`JENKINS_URL`)
+- Generic CI (`CI`)
+
+**Why CI Behavior Differs:**
+
+In CI, commits to main are legitimate (result of PR merges via GitHub UI). The hook allows these commits to proceed without prompting since:
+
+- PRs already passed all checks before merging
+- CI has no interactive terminal for prompts
+- Rejecting would break CI pipeline on main branch
 
 **Test it:**
 
@@ -208,6 +237,24 @@ gh pr create --fill
 # Expected: PR created successfully, CI runs
 ```
 
+### Test 4: CI Environment Simulation
+
+```bash
+# Simulate GitHub Actions CI
+export GITHUB_ACTIONS=true
+git checkout main
+echo "test" >> test.txt
+git add test.txt
+git commit -m "test: CI simulation"
+
+# Expected: No prompt, commit succeeds with CI message
+# Output: "ℹ️  CI environment detected: Allowing commit to 'main' branch"
+
+# Clean up
+unset GITHUB_ACTIONS
+git reset HEAD~1
+```
+
 ## Troubleshooting
 
 ### Pre-commit Hook Not Running
@@ -248,6 +295,28 @@ git commit --no-verify -m "emergency fix"
 1. Make emergency push
 1. Re-enable branch protection immediately
 1. Create follow-up PR to document the emergency change
+
+### CI Failing on Main Branch
+
+**Problem:** Pre-commit hook fails in CI with exit code 1
+
+**Solution:** This was fixed in PR #[TBD]. The hook now detects CI environments and skips the interactive prompt.
+
+**Verify the fix:**
+
+```bash
+# Check hook has CI detection
+grep -A 10 "is_ci()" .git-hooks/check-branch-protection.sh
+
+# Should show function checking GITHUB_ACTIONS, CI, etc.
+```
+
+**If still failing:**
+
+1. Verify the hook file is updated
+1. Check CI environment variables are set
+1. Review CI logs for the actual error
+1. Ensure hook is executable: `chmod +x .git-hooks/check-branch-protection.sh`
 
 ## Best Practices
 

--- a/tasks/bug-fixes/007-fix-ci-branch-protection.md
+++ b/tasks/bug-fixes/007-fix-ci-branch-protection.md
@@ -17,6 +17,7 @@ The branch protection pre-commit hook (`.git-hooks/check-branch-protection.sh`) 
 **Issue**: The hook prompts for user input when committing to protected branches (main/master), but CI environments cannot provide interactive input, causing the hook to fail with exit code 1.
 
 **Impact**:
+
 - CI fails on all commits to main branch
 - Blocks PR merges (even though the PR itself passed all checks)
 - Forces use of `--no-verify` to bypass hooks
@@ -41,10 +42,10 @@ if [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]; then
     echo "⚠️  WARNING: You are committing directly to the '$BRANCH' branch!"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     # ... warning message ...
-    
+
     read -p "⚠️  Continue committing to '$BRANCH'? [y/N] " -n 1 -r  # FAILS IN CI
     echo ""
-    
+
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         echo "❌ Commit aborted."
         exit 1
@@ -97,7 +98,7 @@ is_ci() {
     [[ -n "${JENKINS_URL}" ]] && return 0
     # Generic CI indicator
     [[ -n "${CI}" ]] && return 0
-    
+
     return 1
 }
 
@@ -107,7 +108,7 @@ if [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]; then
         echo "ℹ️  CI environment detected: Allowing commit to '$BRANCH' branch"
         exit 0
     fi
-    
+
     # Local: Warn and prompt for confirmation
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -158,6 +159,7 @@ exit 0
 ### Key Changes
 
 1. **Added `is_ci()` function** that detects common CI environments:
+
    - GitHub Actions (`GITHUB_ACTIONS`)
    - GitLab CI (`GITLAB_CI`)
    - Travis CI (`TRAVIS`)
@@ -165,32 +167,37 @@ exit 0
    - Jenkins (`JENKINS_URL`)
    - Generic (`CI`)
 
-2. **CI-specific behavior**: Skip interactive prompt and allow commits
+1. **CI-specific behavior**: Skip interactive prompt and allow commits
+
    - Commits on main in CI are expected (result of PR merges)
    - Log informational message for transparency
 
-3. **Preserve local behavior**: Interactive prompt still works for developers
+1. **Preserve local behavior**: Interactive prompt still works for developers
 
 ## Implementation Steps
 
 1. **Update hook script**
+
    - Add `is_ci()` function to `.git-hooks/check-branch-protection.sh`
    - Add CI detection before interactive prompt
    - Exit early with success if in CI environment
 
-2. **Test locally**
+1. **Test locally**
+
    - Test that local commits to main still prompt for confirmation
    - Test that choosing "No" still aborts the commit
    - Test that choosing "Yes" allows the commit
    - Verify hook still works on feature branches (should pass silently)
 
-3. **Test in CI**
+1. **Test in CI**
+
    - Create test branch with the hook changes
    - Create PR and merge to main
    - Verify CI passes on main branch after merge
    - Check that pre-commit hook shows "CI environment detected" message
 
-4. **Update documentation**
+1. **Update documentation**
+
    - Update `docs/BRANCH_PROTECTION.md` to explain CI behavior
    - Add troubleshooting section for CI failures
    - Document the environment variables checked
@@ -200,6 +207,7 @@ exit 0
 ### Unit Testing (Manual)
 
 1. **Test local main branch commit** (should prompt):
+
    ```bash
    git checkout main
    echo "test" >> test.txt
@@ -208,7 +216,8 @@ exit 0
    # Expected: Prompt appears, can choose Y/N
    ```
 
-2. **Test CI environment simulation** (should skip prompt):
+1. **Test CI environment simulation** (should skip prompt):
+
    ```bash
    export GITHUB_ACTIONS=true
    git checkout main
@@ -219,7 +228,8 @@ exit 0
    unset GITHUB_ACTIONS
    ```
 
-3. **Test feature branch** (should pass silently):
+1. **Test feature branch** (should pass silently):
+
    ```bash
    git checkout -b test/feature
    echo "test" >> test.txt
@@ -231,17 +241,20 @@ exit 0
 ### Integration Testing (CI)
 
 1. **Create PR with fix**
+
    - Branch: `bug-fixes/007-fix-ci-branch-protection`
    - Changes: Updated `.git-hooks/check-branch-protection.sh`
    - Verify all PR checks pass
 
-2. **Merge PR**
+1. **Merge PR**
+
    - Merge via GitHub (squash merge)
    - Watch CI run on main branch
    - Verify pre-commit checks pass
    - Check logs show "CI environment detected" message
 
-3. **Subsequent commits**
+1. **Subsequent commits**
+
    - Make another simple change via PR
    - Merge to main
    - Verify CI continues to pass
@@ -277,23 +290,25 @@ None - This is a standalone fix to the hook script
 The branch protection hook was designed for local development to prevent accidental commits to main. However, in CI:
 
 1. PRs are merged via GitHub UI (not local git)
-2. GitHub creates merge commits on main branch
-3. CI runs pre-commit hooks on the merge commit
-4. Hook detects main branch and prompts for input
-5. CI has no interactive terminal, so prompt fails
-6. CI fails with exit code 1
+1. GitHub creates merge commits on main branch
+1. CI runs pre-commit hooks on the merge commit
+1. Hook detects main branch and prompts for input
+1. CI has no interactive terminal, so prompt fails
+1. CI fails with exit code 1
 
 ### Design Decision: Allow vs Reject in CI
 
 **Decision**: Allow commits to main in CI (chosen approach)
 
 **Rationale**:
+
 - Commits on main in CI are legitimate (result of PR merges)
 - PRs already passed all checks before merging
 - Rejecting would prevent all CI runs on main
 - Local protection is sufficient to prevent accidental direct commits
 
 **Alternative considered**: Reject in CI and require `--no-verify`
+
 - **Rejected because**: Defeats purpose of CI validation
 - Would require modifying GitHub merge process
 - Adds complexity without benefit
@@ -302,14 +317,14 @@ The branch protection hook was designed for local development to prevent acciden
 
 The hook checks multiple environment variables to ensure broad compatibility:
 
-| Variable         | CI System       | Priority |
-|------------------|-----------------|----------|
-| `GITHUB_ACTIONS` | GitHub Actions  | Primary  |
-| `GITLAB_CI`      | GitLab CI       | Common   |
-| `TRAVIS`         | Travis CI       | Common   |
-| `CIRCLECI`       | CircleCI        | Common   |
-| `JENKINS_URL`    | Jenkins         | Common   |
-| `CI`             | Generic         | Fallback |
+| Variable         | CI System      | Priority |
+| ---------------- | -------------- | -------- |
+| `GITHUB_ACTIONS` | GitHub Actions | Primary  |
+| `GITLAB_CI`      | GitLab CI      | Common   |
+| `TRAVIS`         | Travis CI      | Common   |
+| `CIRCLECI`       | CircleCI       | Common   |
+| `JENKINS_URL`    | Jenkins        | Common   |
+| `CI`             | Generic        | Fallback |
 
 This ensures the fix works across different CI platforms if the project moves in the future.
 
@@ -318,6 +333,7 @@ This ensures the fix works across different CI platforms if the project moves in
 **Question**: Does this weaken branch protection?
 
 **Answer**: No, because:
+
 - GitHub branch protection rules still apply
 - PRs still require reviews and passing checks
 - Local commits to main still prompt for confirmation
@@ -329,9 +345,9 @@ This ensures the fix works across different CI platforms if the project moves in
 After fixing this issue, consider:
 
 1. **GitHub branch protection rules**: Require PRs for main branch
-2. **CODEOWNERS file**: Require specific reviewers
-3. **Status checks**: Require all checks pass before merge
-4. **Squash merge only**: Enforce in GitHub settings
+1. **CODEOWNERS file**: Require specific reviewers
+1. **Status checks**: Require all checks pass before merge
+1. **Squash merge only**: Enforce in GitHub settings
 
 ## Implementation Notes
 


### PR DESCRIPTION
## Task

**Task File**: `tasks/bug-fixes/007-fix-ci-branch-protection.md`
**GitHub Issue**: Closes #58
**Priority**: HIGH
**Estimated Effort**: 1-2h

## Summary

Fix the branch protection pre-commit hook that was failing in GitHub Actions CI when commits were pushed to the main branch. The hook now detects CI environments and skips the interactive prompt, allowing legitimate merge commits to proceed without blocking the CI pipeline.

## Problem

The hook prompts for user input when committing to protected branches (main/master), but CI environments cannot provide interactive input, causing exit code 1:

```
Check Branch Protection..................................................Failed
- hook id: check-branch-protection
- exit code: 1

⚠️  WARNING: You are committing directly to the 'main' branch!
To proceed anyway: Continue below (not recommended)
To abort and create a feature branch: Press Ctrl+C

##[error]Process completed with exit code 1.
```

**Example Failure**: https://github.com/bdperkin/nhl-scrabble/actions/runs/24514400370/job/71654128092

## Changes

### `.git-hooks/check-branch-protection.sh`

- Added `is_ci()` function that detects CI environments:
  - GitHub Actions (`GITHUB_ACTIONS`)
  - GitLab CI (`GITLAB_CI`)
  - Travis CI (`TRAVIS`)
  - CircleCI (`CIRCLECI`)
  - Jenkins (`JENKINS_URL`)
  - Generic CI (`CI`)
- Skip interactive prompt when CI detected
- Log informational message: "ℹ️  CI environment detected: Allowing commit to 'main' branch"
- Preserve interactive prompt behavior for local development

### `docs/BRANCH_PROTECTION.md`

- Added "In CI Environments" behavior section
- Documented CI detection environment variables
- Explained why CI behavior differs from local
- Added Test 4: CI environment simulation instructions
- Added troubleshooting section for CI failures

## Implementation Details

**Design Decision**: Allow commits to main in CI (vs reject)

**Rationale**:

- Commits on main in CI are legitimate (result of PR merges via GitHub UI)
- PRs already passed all checks before merging
- Rejecting would prevent all CI runs on main
- Local protection still enforced for developers

**CI Detection Strategy**:

The hook checks multiple CI environment variables to ensure broad compatibility across different platforms. This future-proofs the solution if the project moves to a different CI system.

## Testing

✅ **Manual Testing**:

- Tested local main branch commit (prompts for confirmation) ✓
- Tested CI environment simulation (skips prompt, shows message) ✓  
- Tested feature branch commit (passes silently) ✓
- Verified hook is executable ✓

✅ **Pre-commit Hooks**: All 56 hooks passed locally

✅ **CI Testing**: Will verify CI passes on main after merge

## Acceptance Criteria

- [x] Hook detects CI environment using standard environment variables
- [x] Hook allows commits to main in CI without prompting
- [x] Hook logs informational message when skipping prompt in CI
- [x] Hook still prompts for confirmation when committing to main locally
- [x] Hook allows bypass via "Y" response locally
- [x] Hook aborts commit via "N" response locally
- [x] Hook passes silently on feature branches (local and CI)
- [x] Documentation updated with CI behavior explanation
- [x] All tests pass

**Pending** (will verify after merge):

- [ ] CI passes on commits to main branch (no more exit code 1)

## Documentation

- ✅ Updated `docs/BRANCH_PROTECTION.md`:
  - Added CI environment behavior section
  - Added CI detection documentation
  - Added CI environment simulation test
  - Added troubleshooting for CI failures
- ✅ Commit message includes detailed implementation notes
- ✅ Task file will be updated with implementation notes after merge

## Breaking Changes

None - This is a bug fix that restores expected behavior.

## Migration Required

None - The fix is automatically applied to all users via the updated hook script.

## Performance Impact

Minimal - Only adds environment variable checks before the prompt.

## Security Considerations

**Question**: Does this weaken branch protection?

**Answer**: No, because:

- GitHub branch protection rules still apply
- PRs still require reviews and passing checks
- Local commits to main still prompt for confirmation
- Only CI environment bypasses the prompt (legitimate merge commits)
- CI runs are triggered by legitimate merges, not arbitrary commits

## Related PRs

None

## Next Steps

After merge:

1. ✅ CI will test the fix on main branch
1. ✅ Future PR merges should succeed without hook failure
1. ✅ Local development continues to have branch protection