### PR TITLE
fix(api): raise NHLApiNotFoundError on 404 responses

### DIFF
--- a/src/nhl_scrabble/api/__init__.py
+++ b/src/nhl_scrabble/api/__init__.py
@@ -1,5 +1,15 @@
 """NHL API client module."""
 
-from nhl_scrabble.api.nhl_client import NHLApiClient
+from nhl_scrabble.api.nhl_client import (
+    NHLApiClient,
+    NHLApiConnectionError,
+    NHLApiError,
+    NHLApiNotFoundError,
+)
 
-__all__ = ["NHLApiClient"]
+__all__ = [
+    "NHLApiClient",
+    "NHLApiConnectionError",
+    "NHLApiError",
+    "NHLApiNotFoundError",
+]

--- a/src/nhl_scrabble/api/nhl_client.py
+++ b/src/nhl_scrabble/api/nhl_client.py
@@ -108,17 +108,17 @@ class NHLApiClient:
             logger.error(f"Error parsing teams response: {e}")
             raise NHLApiError(f"Invalid API response format: {e}") from e
 
-    def get_team_roster(self, team_abbrev: str) -> dict[str, Any] | None:
+    def get_team_roster(self, team_abbrev: str) -> dict[str, Any]:
         """Fetch the current roster for a specific team.
 
         Args:
             team_abbrev: Team abbreviation (e.g., 'TOR', 'MTL')
 
         Returns:
-            Dictionary containing roster data with 'forwards', 'defensemen', and 'goalies' keys,
-            or None if the roster is not available
+            Dictionary containing roster data with 'forwards', 'defensemen', and 'goalies' keys
 
         Raises:
+            NHLApiNotFoundError: If the roster is not found (404 response)
             NHLApiConnectionError: If unable to connect to the API after all retries
             NHLApiError: For other API errors
 
@@ -137,7 +137,7 @@ class NHLApiClient:
 
                 if response.status_code == 404:
                     logger.warning(f"No roster data available for {team_abbrev}")
-                    return None
+                    raise NHLApiNotFoundError(f"Roster not found for team: {team_abbrev}")
 
                 response.raise_for_status()
                 data = response.json()
@@ -177,7 +177,8 @@ class NHLApiClient:
                 logger.error(f"HTTP error fetching {team_abbrev}: {e}")
                 raise NHLApiError(f"HTTP error: {e}") from e
 
-        return None
+        # This should never be reached as all paths above either return or raise
+        raise NHLApiError("Unexpected error: retry loop completed without returning data")
 
     def close(self) -> None:
         """Close the session and release resources."""

--- a/src/nhl_scrabble/processors/team_processor.py
+++ b/src/nhl_scrabble/processors/team_processor.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from typing import Any
 
-from nhl_scrabble.api.nhl_client import NHLApiClient
+from nhl_scrabble.api.nhl_client import NHLApiClient, NHLApiNotFoundError
 from nhl_scrabble.models.player import PlayerScore
 from nhl_scrabble.models.standings import ConferenceStandings, DivisionStandings
 from nhl_scrabble.models.team import TeamScore
@@ -66,9 +66,9 @@ class TeamProcessor:
         for i, (team_abbrev, team_meta) in enumerate(teams_info.items(), 1):
             logger.info(f"Processing {team_abbrev} ({i}/{total_teams})")
 
-            roster = self.api_client.get_team_roster(team_abbrev)
-
-            if not roster:
+            try:
+                roster = self.api_client.get_team_roster(team_abbrev)
+            except NHLApiNotFoundError:
                 logger.warning(f"No roster data for {team_abbrev}")
                 failed_teams.append(team_abbrev)
                 continue

--- a/tests/unit/test_nhl_client.py
+++ b/tests/unit/test_nhl_client.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from nhl_scrabble.api.nhl_client import NHLApiClient, NHLApiConnectionError
+from nhl_scrabble.api.nhl_client import NHLApiClient, NHLApiConnectionError, NHLApiNotFoundError
 
 
 class TestNHLApiClient:
@@ -90,15 +90,14 @@ class TestNHLApiClient:
 
     @patch("nhl_scrabble.api.nhl_client.requests.Session.get")
     def test_get_team_roster_not_found(self, mock_get: Mock) -> None:
-        """Test handling of 404 response."""
+        """Test handling of 404 response raises NHLApiNotFoundError."""
         mock_response = Mock()
         mock_response.status_code = 404
         mock_get.return_value = mock_response
 
         client = NHLApiClient()
-        roster = client.get_team_roster("XXX")
-
-        assert roster is None
+        with pytest.raises(NHLApiNotFoundError, match=r"Roster not found for team: XXX"):
+            client.get_team_roster("XXX")
 
     @patch("nhl_scrabble.api.nhl_client.requests.Session.get")
     def test_get_team_roster_retry(
@@ -138,3 +137,45 @@ class TestNHLApiClient:
         client = NHLApiClient()
         client.close()
         # Verify no exceptions are raised
+
+    @patch("nhl_scrabble.api.nhl_client.requests.Session.get")
+    def test_not_found_error_has_team_name(self, mock_get: Mock) -> None:
+        """Test that NHLApiNotFoundError includes the team name in message."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        client = NHLApiClient()
+        with pytest.raises(NHLApiNotFoundError) as exc_info:
+            client.get_team_roster("TOR")
+
+        assert "TOR" in str(exc_info.value)
+
+    @patch("nhl_scrabble.api.nhl_client.requests.Session.get")
+    def test_not_found_error_is_nhl_api_error(self, mock_get: Mock) -> None:
+        """Test that NHLApiNotFoundError is a subclass of NHLApiError."""
+        from nhl_scrabble.api.nhl_client import NHLApiError
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        client = NHLApiClient()
+        # Should be catchable as NHLApiError
+        with pytest.raises(NHLApiError):
+            client.get_team_roster("TOR")
+
+    @patch("nhl_scrabble.api.nhl_client.requests.Session.get")
+    def test_not_found_error_logs_warning(self, mock_get: Mock, caplog: Any) -> None:
+        """Test that 404 response logs a warning before raising."""
+        import logging
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        client = NHLApiClient()
+        with caplog.at_level(logging.WARNING), pytest.raises(NHLApiNotFoundError):
+            client.get_team_roster("TOR")
+
+        assert "No roster data available for TOR" in caplog.text


### PR DESCRIPTION
## Task

**Task File**: `tasks/bug-fixes/002-unused-exception.md`
**GitHub Issue**: Closes #40
**Priority**: HIGH
**Estimated Effort**: 1-2h

## Summary

Properly implement `NHLApiNotFoundError` exception that was previously defined but never used. The API client now raises the exception instead of returning `None` for 404 responses.

## Problem

The `NHLApiNotFoundError` exception was defined in the codebase but never raised, causing vulture to flag it as unused dead code. Instead, `get_team_roster()` returned `None` for 404 responses, requiring callers to check for `None` and losing error context.

## Solution

- **Raise exception on 404**: `get_team_roster()` now raises `NHLApiNotFoundError` instead of returning `None`
- **Update return type**: Changed from `dict[str, Any] | None` to `dict[str, Any]`
- **Export exceptions**: Added all exception classes to `api/__init__.py` exports
- **Update callers**: Modified `team_processor.py` to catch `NHLApiNotFoundError`
- **Comprehensive tests**: Added 3 new unit tests for exception handling

## Changes

- `src/nhl_scrabble/api/__init__.py` - Export all exception classes
- `src/nhl_scrabble/api/nhl_client.py` - Raise exception on 404, update return type
- `src/nhl_scrabble/processors/team_processor.py` - Catch NHLApiNotFoundError
- `tests/unit/test_nhl_client.py` - Add exception tests, update existing test

## Testing

- ✅ **Unit tests**: 13 tests in test_nhl_client.py (all passing)
  - Test exception is raised on 404
  - Test exception message includes team name
  - Test exception is subclass of NHLApiError
  - Test warning is logged before raising
- ✅ **Integration tests**: 1 test in test_full_workflow.py (passing)
  - Verifies team_processor handles exception correctly
- ✅ **All tests**: 65/65 passing
- ✅ **Coverage**: 54.39% overall (nhl_client.py: 75.82%)

## Acceptance Criteria

- [x] `NHLApiNotFoundError` is raised for 404 responses
- [x] `get_team_roster()` return type is `dict[str, Any]` (not `| None`)
- [x] All callers properly handle the exception
- [x] Vulture no longer flags `NHLApiNotFoundError` as unused
- [x] Unit tests verify exception is raised and propagated
- [x] Type checking passes with strict mypy settings
- [x] All 55 pre-commit hooks pass

## Benefits

1. **Better error handling**: Explicit exceptions provide better error context than `None` returns
2. **Pythonic**: Follows "ask forgiveness not permission" pattern
3. **Type safety**: Eliminates `None` checks and potential `NoneType` errors
4. **Stack traces**: Exceptions preserve full call stack for debugging
5. **Clean code**: Vulture no longer flags exception as unused

## Breaking Changes

None - this is a bug fix that makes the API work as originally intended.

## Documentation

Docstrings updated to document the `NHLApiNotFoundError` exception in `get_team_roster()`.