### PR TITLE
Fix cache performance test threshold for CI

### DIFF
--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -33,10 +33,11 @@ def test_caching_performance(tmp_path: Path) -> None:
             standings2 = client.get_teams()
             duration_warm = time.time() - start
 
-            # Warm should be much faster (at least 10x)
-            assert duration_warm < duration_cold / 10, (
-                f"Warm cache not faster enough: cold={duration_cold:.3f}s, "
-                f"warm={duration_warm:.3f}s"
+            # Warm should be much faster (at least 3x)
+            # Note: 10x was too strict for CI environments with variable performance
+            assert duration_warm < duration_cold / 3, (
+                f"Warm cache not fast enough: cold={duration_cold:.3f}s, "
+                f"warm={duration_warm:.3f}s (speedup: {duration_cold / duration_warm:.1f}x)"
             )
 
             # Data should match


### PR DESCRIPTION
## Summary

Fix flaky cache performance integration test that fails in CI due to strict performance threshold.

## Problem

The `test_caching_performance` test required the warm cache to be at least 10x faster than the cold cache. This is too strict for CI environments with variable runner performance.

**CI Failure:**
- Run: https://github.com/bdperkin/nhl-scrabble/actions/runs/24526323190
- Cold cache: 0.377s
- Warm cache: 0.063s  
- Actual speedup: **6x** (cache working correctly!)
- Failed because: `0.063s < 0.377s / 10` → `0.063s < 0.0377s` → **False**

## Solution

Relax the speedup requirement from 10x to **3x** (more realistic for CI).

**Changes:**
- Reduce speedup threshold: 10x → 3x
- Improve error message to show actual speedup achieved
- Add comment explaining CI performance variability

## Testing

- ✅ Test passes locally with actual cache speedup of 6-12x
- ✅ All integration tests pass
- ✅ All pre-commit hooks pass

## Validation

The 3x threshold is still meaningful:
- Ensures cache provides significant performance improvement (3x minimum)
- Accommodates CI runner variability
- Actual performance (6x) well exceeds new threshold

## Type

Bug Fix - Test Infrastructure