### PR TITLE
feat: add Python 3.15-dev experimental support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        experimental: [false]
+        include:
+          - python-version: "3.15-dev"
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout code
@@ -81,6 +87,7 @@ jobs:
           - py312
           - py313
           - py314
+          - py315
           - ruff-check
           - mypy
           - coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No breaking changes - existing Python 3.10-3.13 users unaffected
   - Ensures access to latest Python features and performance improvements
 
+- **Python 3.15-dev Experimental Support** - Early compatibility testing for Python 3.15-dev
+
+  - Added Python 3.15-dev to CI/CD test matrix with `continue-on-error: true`
+  - Failures on 3.15-dev do NOT block CI or prevent merging (informational only)
+  - Added py315 to tox environments for local testing (optional)
+  - Documented experimental status in README.md and CLAUDE.md
+  - Intentionally NOT updated in pyproject.toml (3.15 not officially released)
+  - Enables proactive compatibility testing before Python 3.15 release
+  - Allows early detection of breaking changes and migration issues
+  - Will be upgraded to official support when Python 3.15 is released
+
 - **HTML Output Format** - Professional HTML reports with responsive design
 
   - Generate beautiful HTML reports with `--format html`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 NHL Scrabble Score Analyzer is a professional Python package that fetches current NHL roster data and calculates "Scrabble scores" for player names based on standard Scrabble letter values. It generates comprehensive reports showing team, division, and conference standings based on these scores, complete with a mock playoff bracket.
 
 **Current Version:** 2.0.0
-**Python:** 3.10-3.14
+**Python:** 3.10-3.14 (supported), 3.15-dev (experimental)
 **License:** MIT
 **Pre-commit Hooks:** 54 hooks (comprehensive quality checks)
 **Dependency Management:** UV with deterministic lock file
@@ -661,10 +661,17 @@ The project has comprehensive CI:
 
 ```yaml
 jobs:
-  test:        # Test on py3.10, 3.11, 3.12, 3.13, 3.14, 3.15
+  test:        # Test on py3.10-3.14 (required), py3.15-dev (experimental)
   tox:         # Tox with UV (matrix: py310, py311, py312, py313, py314, py315, ruff-check, mypy, coverage)
   pre-commit:  # Pre-commit with UV
 ```
+
+**Python Version Testing:**
+
+- **Required**: Python 3.10, 3.11, 3.12, 3.13, 3.14 (must all pass)
+- **Experimental**: Python 3.15-dev (`continue-on-error: true`, informational only)
+
+Python 3.15-dev is tested for early compatibility checking but failures do NOT block CI or prevent merging.
 
 **Optimization:**
 
@@ -908,7 +915,7 @@ The project uses UV automatically via tox-uv:
 ## Project Statistics
 
 - **Package:** nhl-scrabble 2.0.0
-- **Python:** 3.10, 3.11, 3.12, 3.13, 3.14
+- **Python:** 3.10, 3.11, 3.12, 3.13, 3.14 (supported), 3.15-dev (experimental)
 - **Lines of Code:** ~1,866 (src)
 - **Lines of Tests:** ~680 (tests)
 - **Test Coverage:** 49.93% overall, >90% on core modules

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ pip install -e ".[dev]"
 
 ### Requirements
 
-- Python 3.10-3.14
+- **Supported**: Python 3.10, 3.11, 3.12, 3.13, 3.14
+- **Experimental**: Python 3.15-dev (CI testing only, may have issues)
 - Dependencies: `requests`, `click`, `pydantic`, `python-dotenv`, `rich`
 - Note: UV acceleration is automatic when using tox (via tox-uv plugin)
 
@@ -600,7 +601,7 @@ All Dependabot PRs are automatically labeled, assigned, and follow conventional 
 - **Makefile Targets**: 55 documented targets
 - **Pre-commit Hooks**: 54 hooks (meta, pre-commit-hooks, pygrep-hooks, isort, interrogate, deptry, unimport, pydocstyle, vulture, blocklint, gitlint, absolufy-imports, validate-pyproject, pyroma, tox-ini-fmt, yamllint, codespell, pymarkdown, mdformat, doc8, rstcheck, uv, flake8, autoflake, black, docformatter, ruff, mypy)
 - **Dependency Lock**: uv.lock with 1,957 lines (deterministic builds)
-- **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13, 3.14
+- **CI/CD**: GitHub Actions on Python 3.10, 3.11, 3.12, 3.13, 3.14 (required), 3.15-dev (experimental)
 
 ______________________________________________________________________
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ env_list =
     black
     docformatter
     rstcheck
-    py{314, 313, 312, 311, 310}
+    py{315, 314, 313, 312, 311, 310}
 skip_missing_interpreters = true
 
 [testenv]
@@ -360,6 +360,15 @@ commands_pre =
 commands =
     rstcheck --recursive {posargs:docs}
 labels = quality, docs
+
+[testenv:py315]
+description = Experimental testing on Python 3.15-dev (may fail, non-blocking)
+extras =
+    test
+commands_pre =
+    pytest --version
+commands =
+    pytest {posargs:tests/}
 
 [testenv:py{310,311,312,313}]
 description = Run tests with Python {envname}


### PR DESCRIPTION
## Task

**Task File**: `tasks/enhancement/005-python-315-dev-support.md`
**GitHub Issue**: Closes #100

## Summary

Add experimental Python 3.15-dev support for early compatibility testing. This implementation uses `continue-on-error: true` to ensure 3.15-dev test failures do NOT block CI or prevent merging.

## Changes

### CI/CD Updates
- Added Python 3.15-dev to GitHub Actions CI matrix with `experimental: true`
- Set `continue-on-error: ${{ matrix.experimental }}` to make 3.15-dev failures non-blocking
- Added py315 to tox job matrix

### Tox Configuration
- Added py315 to `env_list` in tox.ini
- Created `[testenv:py315]` with experimental description
- Uses same test commands as other Python versions

### Documentation Updates
- **README.md**: Added experimental support notice separating supported vs experimental versions
- **CLAUDE.md**: Added Python version testing policy explaining non-blocking behavior
- **CHANGELOG.md**: Documented experimental support with implementation details

## Key Design

**Non-Blocking CI**:
- Python 3.15-dev failures are informational only
- All required versions (3.10-3.14) must still pass
- CI passes even if 3.15-dev fails

**Package Support**:
- `pyproject.toml` NOT updated (remains `>=3.10,<3.15`)
- Package installation not officially supported on 3.15-dev
- Focus is on early compatibility detection

## Testing

- ✅ Pre-commit hooks: All passing
- ✅ Commit created successfully
- ⏳ CI validation: Awaiting GitHub Actions
- ⏳ Python 3.15-dev test: Expected to run (may fail, non-blocking)

## Acceptance Criteria

- [x] Add Python 3.15-dev to CI matrix with experimental flag
- [x] Set continue-on-error for experimental versions
- [x] Add py315 to tox environment list
- [x] Create [testenv:py315] section
- [x] Update README with experimental support notice
- [x] Update CLAUDE.md with testing policy
- [x] Update CHANGELOG with experimental support entry
- [x] Do NOT update pyproject.toml requires-python
- [x] All pre-commit hooks pass
- [x] Commit uses conventional format
- [ ] CI runs Python 3.15-dev tests (informational)
- [ ] CI passes for all required versions (3.10-3.14)