### PR TITLE
Security: Fix CodeQL findings and add clarifying comments

### DIFF
--- a/src/nhl_scrabble/exporters/excel_exporter.py
+++ b/src/nhl_scrabble/exporters/excel_exporter.py
@@ -77,6 +77,8 @@ class ExcelExporter:
                     if cell.value:
                         max_length = max(max_length, len(str(cell.value)))
                 except (AttributeError, TypeError):
+                    # Ignore cells with values that can't be converted to string
+                    # (e.g., merged cells, formula errors, or special cell types)
                     pass
 
             adjusted_width = min(max_length + 2, 50)  # Cap at 50

--- a/tests/unit/test_ssrf_protection.py
+++ b/tests/unit/test_ssrf_protection.py
@@ -172,8 +172,11 @@ class TestValidateUrlForSsrf:
 
     def test_allowed_domains_constant(self) -> None:
         """Test that ALLOWED_DOMAINS constant is correctly configured."""
-        assert "api-web.nhle.com" in ALLOWED_DOMAINS
-        assert "api.nhle.com" in ALLOWED_DOMAINS
+        # These are test assertions, not URL validation - CodeQL false positive
+        assert (
+            "api-web.nhle.com" in ALLOWED_DOMAINS
+        )  # lgtm[py/incomplete-url-substring-sanitization]
+        assert "api.nhle.com" in ALLOWED_DOMAINS  # lgtm[py/incomplete-url-substring-sanitization]
         assert len(ALLOWED_DOMAINS) >= 2
 
     def test_blocked_ip_ranges_constant(self) -> None:

--- a/tests/unit/test_ssrf_protection.py
+++ b/tests/unit/test_ssrf_protection.py
@@ -175,8 +175,8 @@ class TestValidateUrlForSsrf:
         # These are test assertions, not URL validation - CodeQL false positive
         assert (
             "api-web.nhle.com" in ALLOWED_DOMAINS
-        )  # lgtm[py/incomplete-url-substring-sanitization]
-        assert "api.nhle.com" in ALLOWED_DOMAINS  # lgtm[py/incomplete-url-substring-sanitization]
+        )  # codeql[py/incomplete-url-substring-sanitization]
+        assert "api.nhle.com" in ALLOWED_DOMAINS  # codeql[py/incomplete-url-substring-sanitization]
         assert len(ALLOWED_DOMAINS) >= 2
 
     def test_blocked_ip_ranges_constant(self) -> None:


### PR DESCRIPTION
## Security Finding

**Issue**: Closes #209  
**Type**: CodeQL Code Scanning  
**Severity**: NOTE (Alert #23), WARNING (Alerts #8 & #9)

## Summary

This PR addresses three CodeQL findings:
- **Alert #23**: Empty except block with no explanatory comment
- **Alerts #8 & #9**: False positive URL sanitization warnings in test code

## Changes

### Alert #23: Empty Except Block (Code Quality)
- **File**: `src/nhl_scrabble/exporters/excel_exporter.py:79`
- **Fix**: Added explanatory comment to the empty except block
- **Rationale**: The except clause handles AttributeError and TypeError when processing Excel cells that can't be converted to strings (merged cells, formula errors, special cell types). This is intentional defensive programming.

### Alerts #8 & #9: URL Substring Sanitization (False Positives)
- **File**: `tests/unit/test_ssrf_protection.py:175-176`
- **Fix**: Added CodeQL suppression comments (`lgtm[py/incomplete-url-substring-sanitization]`)
- **Rationale**: These are test assertions verifying that specific domain strings exist in a constant list, not URL validation code. CodeQL incorrectly identified them as security-relevant.

## Security Impact

**Before**: 
- CodeQL flagged 3 alerts (1 code quality, 2 false positives)
- Empty except block lacked explanation

**After**: 
- Code quality improved with explanatory comment
- False positives suppressed with clear reasoning
- No actual security vulnerabilities present

**Risk Reduced**: None (these were not real security issues)

## Testing

- ✅ All existing tests pass
- ✅ Excel exporter tests verify comment doesn't affect functionality
- ✅ SSRF protection tests still validate constants correctly
- ✅ No new vulnerabilities introduced
- ✅ Ruff, mypy, and all pre-commit hooks pass

## Verification

- [x] CodeQL findings addressed appropriately
- [x] No regression in functionality
- [x] Code quality improved with documentation
- [x] False positives properly suppressed with comments

## Additional Notes

The changes are documentation-only - no functional code changes. The empty except block was already correct behavior, it just needed a comment explaining why. The test assertions were false positives from CodeQL's static analysis.