### PR TITLE
perf(reports): optimize string concatenation to list+join pattern

### DIFF
--- a/src/nhl_scrabble/reports/conference_report.py
+++ b/src/nhl_scrabble/reports/conference_report.py
@@ -16,19 +16,21 @@ class ConferenceReporter(BaseReporter):
         Returns:
             Formatted conference report string
         """
-        output = self._format_header("🌎 CONFERENCE SCRABBLE SCORES")
+        parts = [self._format_header("🌎 CONFERENCE SCRABBLE SCORES")]
 
         sorted_conferences = self._sort_by_key(
             standings.items(), key=lambda x: x[1].total, reverse=True
         )
 
         for rank, (conference, data) in enumerate(sorted_conferences, 1):
-            output += f"\n\n#{rank} {conference}"
-            output += f"\n   Total: {self._format_score(data.total)} points"
-            output += f"\n   Teams: {len(data.teams)} ({self._format_team_list(data.teams)})"
-            output += f"\n   Players: {data.player_count}"
-            output += (
-                f"\n   Avg per team: {self._format_average(data.avg_per_team, width=6, decimals=1)}"
+            parts.extend(
+                [
+                    f"\n\n#{rank} {conference}",
+                    f"\n   Total: {self._format_score(data.total)} points",
+                    f"\n   Teams: {len(data.teams)} ({self._format_team_list(data.teams)})",
+                    f"\n   Players: {data.player_count}",
+                    f"\n   Avg per team: {self._format_average(data.avg_per_team, width=6, decimals=1)}",
+                ]
             )
 
-        return output
+        return "".join(parts)

--- a/src/nhl_scrabble/reports/division_report.py
+++ b/src/nhl_scrabble/reports/division_report.py
@@ -16,19 +16,21 @@ class DivisionReporter(BaseReporter):
         Returns:
             Formatted division report string
         """
-        output = self._format_header("🗺️  DIVISION SCRABBLE SCORES")
+        parts = [self._format_header("🗺️  DIVISION SCRABBLE SCORES")]
 
         sorted_divisions = self._sort_by_key(
             standings.items(), key=lambda x: x[1].total, reverse=True
         )
 
         for rank, (division, data) in enumerate(sorted_divisions, 1):
-            output += f"\n\n#{rank} {division}"
-            output += f"\n   Total: {self._format_score(data.total)} points"
-            output += f"\n   Teams: {len(data.teams)} ({self._format_team_list(data.teams)})"
-            output += f"\n   Players: {data.player_count}"
-            output += (
-                f"\n   Avg per team: {self._format_average(data.avg_per_team, width=6, decimals=1)}"
+            parts.extend(
+                [
+                    f"\n\n#{rank} {division}",
+                    f"\n   Total: {self._format_score(data.total)} points",
+                    f"\n   Teams: {len(data.teams)} ({self._format_team_list(data.teams)})",
+                    f"\n   Players: {data.player_count}",
+                    f"\n   Avg per team: {self._format_average(data.avg_per_team, width=6, decimals=1)}",
+                ]
             )
 
-        return output
+        return "".join(parts)

--- a/src/nhl_scrabble/reports/playoff_report.py
+++ b/src/nhl_scrabble/reports/playoff_report.py
@@ -18,17 +18,19 @@ class PlayoffReporter(BaseReporter):
         Returns:
             Formatted playoff report string
         """
-        output = self._format_header("🎰 WILD CARD PLAYOFF STANDINGS (Scrabble Edition)")
-        output += "\nTop 3 from each division + 2 wild cards per conference"
-        output += "\nTiebreaker: Average points per player"
-        output += "\n\nLegend: x-Clinched Playoff, y-Clinched Division, z-Clinched Conference,"
-        output += "\n        p-Presidents' Trophy, e-Eliminated"
+        parts = [
+            self._format_header("🎰 WILD CARD PLAYOFF STANDINGS (Scrabble Edition)"),
+            "\nTop 3 from each division + 2 wild cards per conference",
+            "\nTiebreaker: Average points per player",
+            "\n\nLegend: x-Clinched Playoff, y-Clinched Division, z-Clinched Conference,",
+            "\n        p-Presidents' Trophy, e-Eliminated",
+        ]
 
         for conference in ["Eastern", "Western"]:
             if conference not in standings:
                 continue
 
-            output += self._format_subheader(f"\n{conference} Conference")
+            parts.append(self._format_subheader(f"\n{conference} Conference"))
 
             # Group teams by division and playoff status
             teams_by_division = self._group_teams_by_division(standings[conference])
@@ -45,23 +47,22 @@ class PlayoffReporter(BaseReporter):
                 ]
 
                 if playoff_division_teams:
-                    output += f"\n\n  {division} Division:"
-                    for team in playoff_division_teams:
-                        output += self._format_team_line(team)
+                    parts.append(f"\n\n  {division} Division:")
+                    parts.extend(self._format_team_line(team) for team in playoff_division_teams)
 
             # Print wild cards
             if wild_card_teams:
-                output += "\n\n  Wild Card:"
-                for team in wild_card_teams:
-                    output += self._format_team_line(team)
+                parts.append("\n\n  Wild Card:")
+                parts.extend(self._format_team_line(team) for team in wild_card_teams)
 
             # Print eliminated teams
             if eliminated_teams:
-                output += "\n\n  Eliminated from Playoff Contention:"
-                for team in eliminated_teams:
-                    output += self._format_team_line(team, show_seed=False)
+                parts.append("\n\n  Eliminated from Playoff Contention:")
+                parts.extend(
+                    self._format_team_line(team, show_seed=False) for team in eliminated_teams
+                )
 
-        return output
+        return "".join(parts)
 
     def _group_teams_by_division(self, teams: list[PlayoffTeam]) -> dict[str, list[PlayoffTeam]]:
         """Group teams by division.

--- a/src/nhl_scrabble/reports/stats_report.py
+++ b/src/nhl_scrabble/reports/stats_report.py
@@ -96,35 +96,37 @@ class StatsReporter(BaseReporter):
             Formatted statistics report string
         """
         all_players, division_standings, conference_standings = data
-        output = ""
+        parts = []
 
         # Top players overall
-        output += self._format_header(
-            f"🌟 TOP {self.top_players_count} HIGHEST-SCORING PLAYERS (Across All Teams)"
+        parts.append(
+            self._format_header(
+                f"🌟 TOP {self.top_players_count} HIGHEST-SCORING PLAYERS (Across All Teams)"
+            )
         )
 
         top_players = heapq.nlargest(
             self.top_players_count, all_players, key=lambda x: x.full_score
         )
 
-        for rank, player in enumerate(top_players, 1):
-            div_abbrev = player.division.split()[0][:3].upper()
-            output += (
-                f"\n{rank:2}. {player.full_name:30} ({player.team:3}/{div_abbrev}): "
-                f"{self._format_score(player.full_score, width=3)} points "
-                f"[First: {self._format_score(player.first_score, width=2)}, "
-                f"Last: {self._format_score(player.last_score, width=2)}]"
-            )
+        parts.extend(
+            f"\n{rank:2}. {player.full_name:30} ({player.team:3}/{div_abbrev}): "
+            f"{self._format_score(player.full_score, width=3)} points "
+            f"[First: {self._format_score(player.first_score, width=2)}, "
+            f"Last: {self._format_score(player.last_score, width=2)}]"
+            for rank, player in enumerate(top_players, 1)
+            for div_abbrev in [player.division.split()[0][:3].upper()]
+        )
 
         # Fun stats
-        output += self._format_header("🎯 FUN STATS")
+        parts.append(self._format_header("🎯 FUN STATS"))
 
         # Calculate all statistics in a single pass
         stats = self._calculate_player_statistics(all_players)
 
         # Highest scoring first name
         top_first = stats["top_first"]
-        output += (
+        parts.append(
             f"\nHighest First Name: {top_first.first_name} "
             f"({top_first.full_name}, {top_first.team}) = "
             f"{self._format_score(top_first.first_score)} points"
@@ -132,17 +134,21 @@ class StatsReporter(BaseReporter):
 
         # Highest scoring last name
         top_last = stats["top_last"]
-        output += (
+        parts.append(
             f"\nHighest Last Name: {top_last.last_name} "
             f"({top_last.full_name}, {top_last.team}) = "
             f"{self._format_score(top_last.last_score)} points"
         )
 
         # Average scores overall
-        output += "\n\nLeague-Wide Average Scores:"
-        output += f"\n  Full Name: {self._format_average(stats['avg_full'], width=5)}"
-        output += f"\n  First Name: {self._format_average(stats['avg_first'], width=5)}"
-        output += f"\n  Last Name: {self._format_average(stats['avg_last'], width=5)}"
+        parts.extend(
+            [
+                "\n\nLeague-Wide Average Scores:",
+                f"\n  Full Name: {self._format_average(stats['avg_full'], width=5)}",
+                f"\n  First Name: {self._format_average(stats['avg_first'], width=5)}",
+                f"\n  Last Name: {self._format_average(stats['avg_last'], width=5)}",
+            ]
+        )
 
         # Division with highest average per player
         division_avg_per_player = {
@@ -152,7 +158,7 @@ class StatsReporter(BaseReporter):
 
         if division_avg_per_player:
             top_division = max(division_avg_per_player.items(), key=lambda x: x[1])
-            output += (
+            parts.append(
                 f"\n\nHighest Avg Division (per player): "
                 f"{top_division[0]} = {self._format_average(top_division[1])} points/player"
             )
@@ -165,9 +171,9 @@ class StatsReporter(BaseReporter):
 
         if conference_avg_per_player:
             top_conference = max(conference_avg_per_player.items(), key=lambda x: x[1])
-            output += (
+            parts.append(
                 f"\nHighest Avg Conference (per player): "
                 f"{top_conference[0]} = {self._format_average(top_conference[1])} points/player"
             )
 
-        return output
+        return "".join(parts)

--- a/src/nhl_scrabble/reports/team_report.py
+++ b/src/nhl_scrabble/reports/team_report.py
@@ -26,14 +26,14 @@ class TeamReporter(BaseReporter):
         Returns:
             Formatted team report string
         """
-        output = self._format_header("📊 TEAM SCRABBLE SCORES (Sorted by Total Score)")
+        parts = [self._format_header("📊 TEAM SCRABBLE SCORES (Sorted by Total Score)")]
 
         sorted_teams = self._sort_by_key(
             team_scores.items(), key=lambda x: x[1].total, reverse=True
         )
 
         for rank, (team_abbrev, team_data) in enumerate(sorted_teams, 1):
-            output += (
+            parts.append(
                 f"\n\n#{rank} {team_abbrev} ({team_data.division}): "
                 f"{self._format_score(team_data.total)} points ({team_data.player_count} players)"
             )
@@ -43,11 +43,11 @@ class TeamReporter(BaseReporter):
                 self.top_players_per_team, team_data.players, key=lambda x: x.full_score
             )
 
-            for i, player in enumerate(top_players, 1):
-                output += (
-                    f"\n   {i}. {player.full_name}: {self._format_score(player.full_score)} "
-                    f"({player.first_name}={self._format_score(player.first_score, width=2)}, "
-                    f"{player.last_name}={self._format_score(player.last_score, width=2)})"
-                )
+            parts.extend(
+                f"\n   {i}. {player.full_name}: {self._format_score(player.full_score)} "
+                f"({player.first_name}={self._format_score(player.first_score, width=2)}, "
+                f"{player.last_name}={self._format_score(player.last_score, width=2)})"
+                for i, player in enumerate(top_players, 1)
+            )
 
-        return output
+        return "".join(parts)


### PR DESCRIPTION
## Summary

Optimizes report generation performance by replacing O(n²) string concatenation with O(n) list+join pattern across all report generators.

## Changes

- **TeamReporter**: Use list+join pattern with generator expressions and BaseReporter formatting methods
- **StatsReporter**: Combine list+join with `_format_score()`, `_format_average()`, and efficient statistics calculation
- **DivisionReporter**: Use `parts.extend()` with BaseReporter utility methods
- **ConferenceReporter**: Use `parts.extend()` with BaseReporter utility methods

## Performance Impact

String concatenation changed from O(n²) to O(n):
- **Before**: Each `+=` creates a new string object and copies all existing characters
- **After**: List operations are O(1), final join is O(n)

For reports with 100+ lines, this provides measurable performance improvement while maintaining clean, formatted output using BaseReporter methods.

## Testing

- ✅ All existing tests pass
- ✅ Output format unchanged (verified manually)
- ✅ Pre-commit hooks pass

## Closes

Closes #186 (rebased version)
Completes tasks/optimization/001-optimize-report-string-concatenation.md