### PR TITLE
refactor(ci): Migrate from deprecated codecov/test-results-action to codecov/codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: always()
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit-py${{ matrix.python-version }}.xml
+          report_type: test_results
           fail_ci_if_error: false
           verbose: true
 
@@ -185,10 +186,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: always()
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit*.xml
+          report_type: test_results
           fail_ci_if_error: false
           verbose: true
 


### PR DESCRIPTION
## Task

**Task File**: `tasks/refactoring/020-migrate-codecov-test-results-action.md`
**GitHub Issue**: Closes #285
**Priority**: MEDIUM
**Estimated Effort**: 30min-1h

## Summary

Migrate from deprecated `codecov/test-results-action@v1` to the unified `codecov/codecov-action@v6` with `report_type: test_results` parameter. This ensures compatibility with Codecov's maintained action and eliminates deprecation warnings.

## Changes

- **Test job (lines 88-95)**: Updated to use `codecov/codecov-action@v6` with `report_type: test_results`
- **Tox job (lines 186-193)**: Updated to use `codecov/codecov-action@v6` with `report_type: test_results`
- **Removed**: All usage of deprecated `codecov/test-results-action@v1`
- **Maintained**: All existing parameters (token, files, fail_ci_if_error, verbose, if: always())

## Implementation Details

### What Changed

Both test results upload steps now use the same action as coverage uploads (`codecov/codecov-action@v6`), differentiated by the `report_type` parameter:

- **Coverage uploads**: `codecov/codecov-action@v6` with default report_type (coverage)
- **Test results uploads**: `codecov/codecov-action@v6` with `report_type: test_results`

### Why These Changes

1. **Avoid deprecation**: `codecov/test-results-action` is deprecated and will be removed
1. **Unified action**: Single maintained action for all Codecov uploads
1. **Consistency**: All Codecov uploads now use v6
1. **Future-proof**: Actively maintained with new features and bug fixes

### Behavior Preserved

- `if: always()` ensures upload even on test failures
- `fail_ci_if_error: false` keeps test results upload non-blocking
- File patterns unchanged (`junit-py${{ matrix.python-version }}.xml` and `junit*.xml`)
- Same token authentication
- Same verbose logging

## Testing

### Pre-Implementation

- ✅ YAML syntax validated (yamllint + Python YAML parser)
- ✅ GitHub Actions workflow schema validated
- ✅ Pre-commit hooks passed

### Post-Implementation (CI will verify)

- [ ] Test job uploads test results successfully
- [ ] Tox job uploads test results successfully
- [ ] No deprecation warnings in CI logs
- [ ] Codecov dashboard displays test results
- [ ] Coverage upload still works (unaffected)
- [ ] All CI checks pass

### Verification Checklist

The CI run for this PR will verify:

1. Both upload steps execute successfully
1. No "deprecated action" warnings appear
1. Test results appear in Codecov dashboard
1. Codecov bot comments on PR with coverage + test results
1. All other CI checks remain unaffected

## Acceptance Criteria

- [x] Test job uses `codecov/codecov-action@v6` with `report_type: test_results`
- [x] Tox job uses `codecov/codecov-action@v6` with `report_type: test_results`
- [x] No usage of deprecated `codecov/test-results-action@v1` remains
- [x] All Codecov uploads use consistent action version (v6)
- [x] YAML syntax is valid
- [x] GitHub Actions workflow validates successfully
- [ ] Test results upload to Codecov in this PR (will verify in CI)
- [ ] Codecov dashboard displays test results correctly (will verify in CI)
- [ ] No deprecation warnings in CI logs (will verify in CI)
- [ ] All CI checks pass (will verify in CI)

## Documentation

No documentation updates required:

- Change is internal to CI workflow
- No user-facing changes
- No API changes
- CLAUDE.md mentions Codecov but not specific action versions

## Breaking Changes

None - this is a drop-in replacement with identical behavior.

## Migration Notes

This migration is fully backward compatible:

- Same authentication mechanism
- Same file upload patterns
- Same Codecov dashboard integration
- Same behavior on test failures
- No changes to `.codecov.yml` configuration

## Performance Impact

No performance impact expected:

- Same upload mechanism
- Same API endpoints
- Unified action may be slightly faster (single implementation)

## Security Considerations

Security remains unchanged:

- Uses existing `CODECOV_TOKEN` secret
- Same authentication mechanism
- Action maintained by Codecov (trusted source)
- No new permissions required

## References

- Codecov documentation: https://docs.codecov.com/docs/codecov-uploader
- codecov-action repository: https://github.com/codecov/codecov-action
- Deprecation notice: https://github.com/codecov/test-results-action