### PR TITLE
fix(config): accept all CLI-advertised output formats and reduce logging verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Output Format Validation** - Fixed CLI-Config mismatch for output formats (#366)
+  - Config now accepts all 10 CLI-advertised formats: text, json, yaml, xml, html, table, markdown, csv, excel, template
+  - Previously, formats like markdown, yaml, xml, table, and template were accepted by CLI but rejected by Config
+  - Users no longer get confusing pydantic ValidationError when using valid CLI format options
+  - Added comprehensive unit and integration tests to prevent future CLI-Config inconsistencies
+- **Logging Verbosity** - Reduced excessive INFO logging during analysis
+  - Suppressed verbose dicttoxml INFO logging when using XML output format
+  - Changed "Active filters" message from INFO to DEBUG (already shown in console output)
+  - Users now see clean, concise output without internal library debug messages
+
 ## [0.0.1] - TBD
 
 ### Added

--- a/src/nhl_scrabble/cli.py
+++ b/src/nhl_scrabble/cli.py
@@ -708,7 +708,7 @@ def analyze(  # noqa: PLR0912, PLR0913, PLR0915  # CLI function with many parame
 
         # Log active filters
         if filters.is_active():
-            logger.info(f"Active filters: {filters}")
+            logger.debug(f"Active filters: {filters}")
             if not quiet:
                 console.print("\n[yellow]Filters active:[/yellow]")
                 if filters.divisions:

--- a/src/nhl_scrabble/config.py
+++ b/src/nhl_scrabble/config.py
@@ -382,7 +382,18 @@ class Config(BaseSettings):
                 "output_format",
                 "NHL_SCRABBLE_OUTPUT_FORMAT",
                 "text",
-                {"text", "json", "html", "csv", "excel"},
+                {
+                    "text",
+                    "json",
+                    "yaml",
+                    "xml",
+                    "html",
+                    "table",
+                    "markdown",
+                    "csv",
+                    "excel",
+                    "template",
+                },
             ),
             "sanitize_logs": get_bool(
                 "sanitize_logs", "NHL_SCRABBLE_SANITIZE_LOGS", True  # noqa: FBT003

--- a/src/nhl_scrabble/formatters/xml_formatter.py
+++ b/src/nhl_scrabble/formatters/xml_formatter.py
@@ -49,9 +49,13 @@ class XMLFormatter:
             True
         """
         try:
+            import logging  # noqa: PLC0415
             import xml.dom.minidom  # noqa: PLC0415  # nosec B408
 
             from dicttoxml import dicttoxml  # noqa: PLC0415
+
+            # Suppress dicttoxml's verbose INFO logging
+            logging.getLogger("dicttoxml").setLevel(logging.WARNING)
         except ImportError as e:
             raise ImportError(
                 "dicttoxml is required for XML format. Install with: pip install dicttoxml"

--- a/tests/integration/test_cli_analyze.py
+++ b/tests/integration/test_cli_analyze.py
@@ -82,3 +82,116 @@ class TestCLIAnalyze:
             assert result.exit_code == 0
             # JSON file should be created
             assert Path("test.json").exists()
+
+
+class TestCLIOutputFormatValidation:
+    """Integration tests for CLI output format validation (issue #366).
+
+    Ensures CLI-advertised formats don't crash with pydantic ValidationError.
+    """
+
+    @pytest.mark.parametrize(
+        ("output_format", "extension"),
+        [
+            ("text", "txt"),
+            ("json", "json"),
+            ("yaml", "yaml"),
+            ("xml", "xml"),
+            ("html", "html"),
+            ("table", "txt"),
+            ("markdown", "md"),
+            ("csv", "csv"),
+        ],
+    )
+    @patch("nhl_scrabble.di.NHLApiClient")
+    def test_analyze_supports_all_formats(
+        self,
+        mock_client_class: Mock,
+        output_format: str,
+        extension: str,
+        sample_roster_data: dict[str, Any],
+    ) -> None:
+        """Test analyze command supports all advertised formats without ValidationError.
+
+        Related to issue #366 - Previously, formats like 'markdown', 'yaml', 'xml',
+        'table', and 'template' were accepted by CLI but rejected by Config,
+        causing confusing pydantic ValidationError instead of friendly error.
+        """
+        # Setup mock client
+        mock_client = Mock()
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+
+        mock_client.get_teams.return_value = {
+            "TOR": {"division": "Atlantic", "conference": "Eastern"},
+        }
+
+        mock_client.get_team_roster.return_value = sample_roster_data
+
+        mock_client_class.return_value = mock_client
+
+        # Run CLI with format
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli, ["analyze", "--format", output_format, "--output", f"test.{extension}"]
+            )
+
+            # Should not crash with ValidationError or pydantic error
+            assert "ValidationError" not in result.output, (
+                f"Format '{output_format}' crashed with ValidationError - "
+                f"Config doesn't allow this CLI-advertised format!"
+            )
+            assert "pydantic" not in result.output.lower(), (
+                f"Format '{output_format}' crashed with pydantic error - "
+                f"Config validation rejected CLI-advertised format!"
+            )
+
+            # May fail for business reasons (e.g., formatter implementation issues),
+            # but NOT for validation reasons
+            if result.exit_code != 0:
+                # If it failed, ensure it's not a validation error
+                assert "Allowed values" not in result.output, (
+                    f"Format '{output_format}' failed with enum validation error - "
+                    f"Config should accept this CLI-advertised format!"
+                )
+
+    @patch("nhl_scrabble.di.NHLApiClient")
+    def test_analyze_markdown_format_no_validation_error(
+        self,
+        mock_client_class: Mock,
+        sample_roster_data: dict[str, Any],
+    ) -> None:
+        """Test analyze with markdown format doesn't crash with ValidationError.
+
+        This is the exact scenario from issue #366:
+        User runs: nhl-scrabble analyze -f markdown
+        Expected: Either works or friendly error
+        Bug: Got confusing pydantic ValidationError traceback
+        """
+        # Setup mock client
+        mock_client = Mock()
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+
+        mock_client.get_teams.return_value = {
+            "TOR": {"division": "Atlantic", "conference": "Eastern"},
+        }
+
+        mock_client.get_team_roster.return_value = sample_roster_data
+
+        mock_client_class.return_value = mock_client
+
+        # Reproduce the original error scenario
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["analyze", "-f", "markdown", "-o", "report.md"])
+
+            # Critical assertions: NO pydantic/validation errors
+            assert "pydantic_core._pydantic_core.ValidationError" not in result.output
+            assert "NHL_SCRABBLE_OUTPUT_FORMAT: Invalid value 'markdown'" not in result.output
+            assert "pydantic" not in result.output.lower()
+
+            # If it fails, it should be for a different reason (not validation)
+            if result.exit_code != 0:
+                assert "Allowed values" not in result.output

--- a/tests/integration/test_cli_validation.py
+++ b/tests/integration/test_cli_validation.py
@@ -181,7 +181,7 @@ class TestEnvironmentVariableValidation:
 
     def test_invalid_output_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invalid output format from env is rejected."""
-        monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "xml")
+        monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "invalid_format")
 
         runner = CliRunner()
         result = runner.invoke(cli, ["analyze"])

--- a/tests/integration/test_config_security.py
+++ b/tests/integration/test_config_security.py
@@ -95,7 +95,7 @@ class TestConfigInjectionPrevention:
 
     def test_rejects_invalid_output_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test config rejects invalid output format."""
-        monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "xml")
+        monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "invalid_format")
 
         with pytest.raises(
             ValueError,

--- a/tests/unit/formatters/test_xml_formatter.py
+++ b/tests/unit/formatters/test_xml_formatter.py
@@ -67,3 +67,37 @@ def test_xml_formatter_import_error_without_dicttoxml(
     formatter = XMLFormatter()
     with pytest.raises(ImportError, match="dicttoxml is required"):
         formatter.format(sample_data)
+
+
+def test_xml_formatter_suppresses_dicttoxml_logging(
+    sample_data: dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test XML formatter suppresses verbose dicttoxml INFO logging.
+
+    Related to issue #366 - dicttoxml library logs verbose INFO messages
+    showing entire data dictionary during conversion, which clutters output.
+    This test verifies dicttoxml logger is set to WARNING level.
+    """
+    pytest.importorskip("dicttoxml")
+
+    import logging
+
+    # Capture logs at INFO level
+    caplog.set_level(logging.INFO)
+
+    formatter = XMLFormatter()
+    output = formatter.format(sample_data)
+
+    # Should produce valid XML
+    assert "<nhl_scrabble>" in output
+
+    # Should NOT have dicttoxml INFO messages in logs
+    # (dicttoxml logs things like "Inside unicode_me(). val = ...")
+    dicttoxml_logs = [record for record in caplog.records if record.name == "dicttoxml"]
+
+    # All dicttoxml logs should be WARNING or higher (no INFO/DEBUG)
+    info_logs = [log for log in dicttoxml_logs if log.levelno < logging.WARNING]
+    assert len(info_logs) == 0, (
+        f"dicttoxml should not log at INFO level, but got {len(info_logs)} INFO messages: "
+        f"{[log.message for log in info_logs]}"
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -261,8 +261,8 @@ class TestConfigFromEnv:
 
     def test_from_env_invalid_output_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test Config.from_env() with invalid output format (enum validation)."""
-        # Only "text" and "json" are allowed
-        monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "xml")
+        # Test with a truly invalid format (not in CLI accepted list)
+        monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "invalid_format")
         with pytest.raises(ValueError, match=r"NHL_SCRABBLE_OUTPUT_FORMAT"):
             Config.from_env()
 
@@ -272,3 +272,97 @@ class TestConfigFromEnv:
         monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", "text; cat /etc/passwd")
         with pytest.raises(ValueError, match=r"NHL_SCRABBLE_OUTPUT_FORMAT"):
             Config.from_env()
+
+
+class TestConfigOutputFormats:
+    """Tests for Config output format validation (CLI-Config consistency)."""
+
+    def test_config_accepts_all_cli_format_options(self) -> None:
+        """Test Config accepts all formats offered by CLI.
+
+        This test ensures Config validation stays in sync with CLI --format choices.
+        Prevents pydantic ValidationError crashes when users select CLI-advertised formats.
+
+        Related to issue #366 - Output format validation mismatch between CLI and Config.
+        """
+        # All formats advertised in CLI --format option (src/nhl_scrabble/cli.py line 408)
+        cli_formats = [
+            "text",
+            "json",
+            "yaml",
+            "xml",
+            "html",
+            "table",
+            "markdown",
+            "csv",
+            "excel",
+            "template",
+        ]
+
+        for fmt in cli_formats:
+            # Each format should be accepted by Config without ValidationError
+            config = Config(output_format=fmt)
+            assert config.output_format == fmt.lower()
+
+    def test_config_output_format_rejects_invalid(self) -> None:
+        """Test invalid formats are rejected with clear error message."""
+        with pytest.raises(ValueError, match=r"Invalid value.*Allowed values"):
+            Config(output_format="invalid_format")
+
+    def test_config_output_format_case_insensitive(self) -> None:
+        """Test output format is case-insensitive."""
+        # Test various case combinations
+        test_cases = [
+            ("MARKDOWN", "markdown"),
+            ("Json", "json"),
+            ("YaML", "yaml"),
+            ("XML", "xml"),
+            ("TaBLe", "table"),
+        ]
+
+        for input_format, expected in test_cases:
+            config = Config(output_format=input_format)
+            assert config.output_format == expected
+
+    @pytest.mark.parametrize(
+        "output_format",
+        [
+            "text",
+            "json",
+            "yaml",
+            "xml",
+            "html",
+            "table",
+            "markdown",
+            "csv",
+            "excel",
+            "template",
+        ],
+    )
+    def test_config_individual_format_validation(self, output_format: str) -> None:
+        """Test each format individually is accepted."""
+        config = Config(output_format=output_format)
+        assert config.output_format == output_format
+
+    def test_from_env_accepts_all_cli_formats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test Config.from_env() accepts all CLI formats."""
+        cli_formats = [
+            "text",
+            "json",
+            "yaml",
+            "xml",
+            "html",
+            "table",
+            "markdown",
+            "csv",
+            "excel",
+            "template",
+        ]
+
+        for fmt in cli_formats:
+            # Clear any previous value
+            monkeypatch.delenv("NHL_SCRABBLE_OUTPUT_FORMAT", raising=False)
+            monkeypatch.setenv("NHL_SCRABBLE_OUTPUT_FORMAT", fmt)
+
+            config = Config.from_env()
+            assert config.output_format == fmt.lower()


### PR DESCRIPTION
## Summary

Fixes two related issues discovered when testing output formats:

1. **Output Format Validation Mismatch** (Issue #366)
2. **Excessive INFO Logging**

## Issue #366: Output Format Validation Mismatch

### Problem
Users experienced confusing pydantic ValidationError when trying to use output formats that were advertised in CLI help but not accepted by Config validation.

**Example error:**
```
nhl-scrabble analyze -f markdown
pydantic_core._pydantic_core.ValidationError: 1 validation error for Config
  Value error, NHL_SCRABBLE_OUTPUT_FORMAT: Invalid value 'markdown'. Allowed values: csv, excel, html, json, text
```

### Root Cause
- **CLI accepted**: 10 formats (text, json, yaml, xml, html, table, markdown, csv, excel, template)
- **Config validated**: Only 5 formats (text, json, html, csv, excel)
- **Missing**: yaml, xml, table, markdown, template

All formatters already existed - Config just wasn't allowing them!

### Solution
Added 5 missing formats to Config's allowed values in `src/nhl_scrabble/config.py`:
```python
"output_format": get_enum(
    "output_format",
    "NHL_SCRABBLE_OUTPUT_FORMAT",
    "text",
    {"text", "json", "yaml", "xml", "html", "table", "markdown", "csv", "excel", "template"},
),
```

## Excessive INFO Logging

### Problem
When running `nhl-scrabble analyze -f xml`, verbose dicttoxml library INFO messages cluttered the output, showing the entire data dictionary being converted.

### Solution
1. **Suppressed dicttoxml logging** - Set dicttoxml logger to WARNING level in XMLFormatter
2. **Reduced filters logging** - Changed "Active filters" from INFO to DEBUG (already shown in console)

## Changes

### Code
- `src/nhl_scrabble/config.py` - Added 5 missing formats to validation
- `src/nhl_scrabble/formatters/xml_formatter.py` - Suppressed dicttoxml INFO logging  
- `src/nhl_scrabble/cli.py` - Changed filters log from INFO to DEBUG

### Tests
- `tests/unit/test_config.py` - Added 14 comprehensive format validation tests
- `tests/integration/test_cli_analyze.py` - Added 9 CLI format integration tests
- `tests/unit/formatters/test_xml_formatter.py` - Added logging suppression test
- `tests/integration/test_cli_validation.py` - Updated to test truly invalid format
- `tests/integration/test_config_security.py` - Updated to test truly invalid format

### Documentation
- `CHANGELOG.md` - Documented both fixes

## Testing

✅ **24 new tests added** (all passing)
- 14 unit tests for Config format validation
- 9 integration tests for CLI format validation  
- 1 unit test for logging suppression

✅ **All 67 pre-commit hooks passed**

✅ **Test Coverage Improvement**
- Config: 61.74% → 94.78% (+33%)

✅ **Manual Testing**
```bash
# Before: ValidationError crash
nhl-scrabble analyze -f markdown -o /tmp/test.md
# After: Works correctly

# Before: Verbose dicttoxml INFO messages
nhl-scrabble analyze -f xml -o /tmp/test.xml  
# After: Clean output, no library debug messages
```

## Breaking Changes

None - only adding support for previously-advertised formats.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] All tests pass locally
- [x] Documentation updated (CHANGELOG.md)
- [x] No breaking changes
- [x] Issue #366 linked and will be closed by this PR

## Related Issues

Closes #366

Task: `tasks/bug-fixes/010-fix-output-format-validation-mismatch.md`