### PR TITLE
Implement automated stale issue/PR management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,96 @@
+name: Stale Issue and PR Management
+
+on:
+  schedule:
+    # Run daily at 1 AM UTC
+    - cron: 0 1 * * *
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark Stale Items
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Stale issue and PR management
+        uses: actions/stale@v9
+        with:
+          # General settings
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 7
+          remove-stale-when-updated: true
+          ascending: true  # Process oldest first
+
+          # Issue-specific settings
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had
+            any activity for 60 days.
+
+            It will be closed in 7 days if no further activity occurs.
+
+            **To keep this issue open:**
+            - Add a comment explaining current status
+            - Add the `keep-open` label
+            - Continue working on it
+
+            Thank you for your contributions! 🙏
+
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+
+            If this issue is still relevant, please:
+            - Reopen it with updated information
+            - Create a new issue with current details
+
+            Thank you! 🙏
+
+          stale-issue-label: stale
+          close-issue-label: closed-by-bot
+          exempt-issue-labels: keep-open,pinned,security,good-first-issue,help-wanted,enhancement,bug
+
+          # PR-specific settings (more aggressive)
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had
+            any activity for 30 days.
+
+            It will be closed in 7 days if no further activity occurs.
+
+            **To keep this PR open:**
+            - Push new commits
+            - Add a comment with an update
+            - Add the `keep-open` label
+            - Request review
+
+            If this PR is blocked on something, please add a comment explaining the situation.
+
+            Thank you for your contribution! 🙏
+
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+
+            If you would like to resume work on this PR:
+            - Reopen it and push new commits
+            - Create a new PR with updated changes
+
+            Thank you for your contribution! 🙏
+
+          stale-pr-label: stale
+          close-pr-label: closed-by-bot
+          exempt-pr-labels: keep-open,pinned,security,work in progress,work-in-progress,wip
+
+          # Performance settings
+          operations-per-run: 100
+          remove-pr-stale-when-updated: true
+          remove-issue-stale-when-updated: true
+
+          # Debugging
+          debug-only: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1198,6 +1198,52 @@ Node.js 24 migration completed (April 2026):
 - ✅ Squash merge only (consistent git history)
 - ✅ Auto-delete branches on merge
 
+### Stale Issue/PR Management
+
+Automated stale management workflow keeps the issue tracker clean and relevant:
+
+**Configuration:**
+
+- **Workflow**: `.github/workflows/stale.yml`
+- **Schedule**: Daily at 1 AM UTC
+- **Manual trigger**: Available via workflow_dispatch
+
+**Timeframes:**
+
+- **Issues**: 60 days inactive → marked stale, 7 days → closed
+- **Pull Requests**: 30 days inactive → marked stale, 7 days → closed
+- **Warning period**: 7 days between stale and close
+
+**Labels:**
+
+- `stale` - Item marked as stale (yellow, #fbca04)
+- `closed-by-bot` - Item auto-closed (gray, #d1d5da)
+- `keep-open` - Prevents stale marking (green, #0e8a16)
+
+**Exempt Labels:**
+
+Issues/PRs with these labels are never marked stale:
+
+- `keep-open`, `pinned`, `security`, `good-first-issue`, `help-wanted`
+- `enhancement`, `bug` (issues only)
+- `work-in-progress`, `wip` (PRs only)
+
+**To Prevent Closure:**
+
+- Add a comment with an update
+- Add the `keep-open` label
+- Continue working on it (push commits for PRs)
+
+**Rationale:**
+
+- **60 days for issues**: Ample time for discussion and intermittent work
+- **30 days for PRs**: PRs should move faster, prevents abandoned code
+- **7-day warning**: Fair notice without being forgotten
+
+**Reopening:**
+
+Closed items can be reopened at any time if still relevant. The bot doesn't prevent reopening.
+
 ## Documentation
 
 **Online Documentation:** https://bdperkin.github.io/nhl-scrabble/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2307,6 +2307,22 @@ If package validation fails in CI:
 1. Commit and push changes
 1. CI will re-run validation
 
+## Stale Issue/PR Policy
+
+To keep the issue tracker relevant and manageable:
+
+- **Issues** inactive for 60 days are marked stale
+- **Pull requests** inactive for 30 days are marked stale
+- Items are closed 7 days after being marked stale
+
+**To prevent closure:**
+
+- Add a comment with an update
+- Add the `keep-open` label
+- Continue working on it
+
+**Closed items can be reopened** at any time if still relevant.
+
 ## Questions?
 
 - Open an issue for bug reports or feature requests

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -212,7 +212,7 @@ Each task includes:
 | 034 | Docker Container Build and Publish Workflow           | MEDIUM   | 3-4 hours           | Active    | [#301](https://github.com/bdperkin/nhl-scrabble/issues/301) | -     |
 | 035 | PR Auto-Labeling Workflow                             | MEDIUM   | 1-2 hours           | Active    | [#302](https://github.com/bdperkin/nhl-scrabble/issues/302) | -     |
 | 036 | PR Size Checker Workflow                              | MEDIUM   | 1-2 hours           | Active    | [#303](https://github.com/bdperkin/nhl-scrabble/issues/303) | -     |
-| 037 | Stale Issue and PR Management Workflow                | MEDIUM   | 1 hour              | Active    | [#304](https://github.com/bdperkin/nhl-scrabble/issues/304) | -     |
+| 037 | Stale Issue and PR Management Workflow                | LOW      | 1 hour              | Completed | [#304](https://github.com/bdperkin/nhl-scrabble/issues/304) | PR [#395](https://github.com/bdperkin/nhl-scrabble/pull/395), completed 2026-04-26, actual effort: 45min |
 | 038 | First-Time Contributor Welcome Workflow               | MEDIUM   | 30 minutes - 1 hour | Active    | [#305](https://github.com/bdperkin/nhl-scrabble/issues/305) | -     |
 | 039 | Performance Benchmark Testing Workflow                | MEDIUM   | 3-4 hours           | Active    | [#306](https://github.com/bdperkin/nhl-scrabble/issues/306) | -     |
 | 040 | Software Bill of Materials (SBOM) Generation Workflow | MEDIUM   | 2-3 hours           | Active    | [#307](https://github.com/bdperkin/nhl-scrabble/issues/307) | -     |
@@ -266,9 +266,9 @@ Each task includes:
 | Optimization | 0      | 13        | 13      |
 | Enhancement  | 11     | 34        | 45      |
 | Testing      | 8      | 23        | 31      |
-| New Features | 37     | 6         | 43      |
+| New Features | 36     | 7         | 43      |
 | Refactoring  | 1      | 29        | 30      |
-| **TOTAL**    | **59** | **130**   | **189** |
+| **TOTAL**    | **58** | **131**   | **189** |
 
 ### Effort Estimates by Category
 
@@ -279,9 +279,9 @@ Each task includes:
 | Optimization | 36.0 hours       |
 | Enhancement  | 219.25 hours     |
 | Testing      | 265.0 hours      |
-| New Features | 227.0 hours      |
+| New Features | 226.0 hours      |
 | Refactoring  | 219.0 hours      |
-| **TOTAL**    | **1066.25 hours**|
+| **TOTAL**    | **1065.25 hours**|
 
 ### Completion Progress
 
@@ -292,9 +292,9 @@ Each task includes:
 | Optimization | 100.0%          |
 | Enhancement  | 75.6%           |
 | Testing      | 74.2%           |
-| New Features | 14.0%           |
+| New Features | 16.3%           |
 | Refactoring  | 96.7%           |
-| **OVERALL**  | **68.8%**       |
+| **OVERALL**  | **69.3%**       |
 
 ### Priority Distribution (Active Tasks)
 
@@ -303,7 +303,7 @@ Each task includes:
 | CRITICAL | 0     |
 | HIGH     | 0     |
 | MEDIUM   | 58    |
-| LOW      | 1     |
+| LOW      | 0     |
 
 ## Recommended Implementation Order
 

--- a/tasks/completed/new-features/037-stale-management-workflow.md
+++ b/tasks/completed/new-features/037-stale-management-workflow.md
@@ -212,20 +212,20 @@ gh issue view <stale-issue-number>
 
 ## Acceptance Criteria
 
-- [ ] Workflow file created: `.github/workflows/stale.yml`
-- [ ] Scheduled to run daily
-- [ ] Issues marked stale after 60 days
-- [ ] PRs marked stale after 30 days
-- [ ] Items closed 7 days after stale
-- [ ] Helpful messages posted
-- [ ] `keep-open` label exempts items
-- [ ] Important labels exempt items (security, etc.)
-- [ ] Stale label removed when updated
-- [ ] Manual trigger available
-- [ ] Required labels created
-- [ ] CONTRIBUTING.md updated
-- [ ] Workflow tested
-- [ ] No false positives in first run
+- [x] Workflow file created: `.github/workflows/stale.yml`
+- [x] Scheduled to run daily
+- [x] Issues marked stale after 60 days
+- [x] PRs marked stale after 30 days
+- [x] Items closed 7 days after stale
+- [x] Helpful messages posted
+- [x] `keep-open` label exempts items
+- [x] Important labels exempt items (security, etc.)
+- [x] Stale label removed when updated
+- [x] Manual trigger available
+- [x] Required labels created
+- [x] CONTRIBUTING.md updated
+- [x] Workflow tested (schema validation, YAML linting)
+- [ ] No false positives in first run (to be verified after deployment)
 
 ## Related Files
 
@@ -363,12 +363,107 @@ gh issue list --label closed-by-bot --state closed
 
 ## Implementation Notes
 
-*To be filled during implementation:*
+**Implemented**: 2026-04-26
+**Branch**: new-features/037-stale-management-workflow
+**PR**: #395 - https://github.com/bdperkin/nhl-scrabble/pull/395
+**Commits**: 1 commit (471dec4)
 
-- Date started:
-- Date completed:
-- Actual effort:
-- Items marked stale in first run:
-- Items closed in first month:
-- Adjustments made to timeframes:
-- Community feedback:
+### Actual Implementation
+
+Successfully implemented the automated stale management workflow as proposed:
+
+**Workflow Configuration:**
+- Created `.github/workflows/stale.yml` using `actions/stale@v9`
+- Scheduled to run daily at 1 AM UTC
+- Manual trigger available via workflow_dispatch
+- Issues: 60 days → stale, 7 days → close
+- PRs: 30 days → stale, 7 days → close
+
+**Labels Created:**
+- `stale` (yellow, #fbca04) - Marks inactive items
+- `keep-open` (green, #0e8a16) - Prevents stale marking
+- `closed-by-bot` (gray, #d1d5da) - Marks auto-closed items
+
+**Documentation Updates:**
+- Added "Stale Issue/PR Policy" section to CONTRIBUTING.md
+- Added "Stale Issue/PR Management" subsection to CLAUDE.md CI/CD section
+- Clear instructions on preventing closure and reopening
+
+**Workflow Features:**
+- Helpful, friendly messages explaining closure
+- Clear instructions on keeping items open
+- Automatic stale label removal when updated
+- Comprehensive exempt labels (security, pinned, etc.)
+- Different timeframes for issues vs PRs (rationale documented)
+
+### Challenges Encountered
+
+**Minor YAML Linting Issues:**
+- Initial commit failed yamllint due to line length (110+ chars)
+- Fixed by wrapping long message lines
+- Resolution: Split messages at 80-100 character boundaries
+
+**Label Naming:**
+- Repository has "work in progress" (with spaces) label
+- Updated workflow to include both formats: "work in progress", "work-in-progress", "wip"
+- Ensures compatibility with existing and new labels
+
+### Deviations from Plan
+
+**No Significant Deviations:**
+- Implementation followed the proposed solution exactly
+- Added support for existing "work in progress" label (with spaces)
+- Minor message text wrapping for YAML linting compliance
+
+### Actual vs Estimated Effort
+
+- **Estimated**: 1 hour
+- **Actual**: ~45 minutes
+- **Variance**: -15 minutes (faster than estimated)
+- **Reason**: Straightforward implementation, well-planned task specification
+
+### Related PRs
+
+- #395 - Main implementation (stale workflow + documentation)
+
+### Lessons Learned
+
+**YAML Line Length:**
+- yamllint enforces 100-character line limit
+- Multi-line YAML strings should be wrapped early
+- Pre-commit hooks catch formatting issues before push
+
+**Label Naming Conventions:**
+- Check existing repository labels before workflow creation
+- Support multiple label name formats (spaces, hyphens)
+- Document label creation for reproducibility
+
+**Testing Approach:**
+- Schema validation (check-jsonschema) catches workflow errors early
+- Pre-commit hooks provide comprehensive validation
+- Manual workflow trigger allows testing before first scheduled run
+
+**Documentation:**
+- Adding policy to CONTRIBUTING.md improves contributor awareness
+- CI/CD documentation in CLAUDE.md helps maintainers understand automation
+- Clear reopening policy reduces contributor friction
+
+### Production Monitoring
+
+**Post-Deployment Tasks:**
+- Monitor first workflow run for false positives
+- Review items marked stale in first week
+- Adjust exempt labels if community feedback suggests changes
+- Track metrics: items staled per month, items closed, items reopened
+
+**Monitoring Commands:**
+```bash
+# List stale items
+gh issue list --label stale
+
+# List auto-closed items
+gh issue list --label closed-by-bot --state closed
+
+# View workflow runs
+gh run list --workflow=stale.yml
+```


### PR DESCRIPTION
## Task

**Task File**: `tasks/new-features/037-stale-management-workflow.md`
**GitHub Issue**: Closes #304
**Priority**: LOW
**Estimated Effort**: 1 hour

## Summary

Implement automated stale issue and PR management workflow using GitHub Actions `actions/stale@v9`. The workflow automatically marks inactive issues (60 days) and PRs (30 days) as stale, then closes them after a 7-day warning period. Helps keep the issue tracker clean and relevant while giving contributors fair warning before closure.

## Changes

**New Files:**
- `.github/workflows/stale.yml` - Automated stale management workflow
  - Scheduled daily at 1 AM UTC
  - Manual trigger available via workflow_dispatch
  - Configurable timeframes and exempt labels

**Created Labels:**
- `stale` (yellow, #fbca04) - Marks items as inactive
- `keep-open` (green, #0e8a16) - Prevents stale marking
- `closed-by-bot` (gray, #d1d5da) - Marks auto-closed items

**Updated Documentation:**
- `CONTRIBUTING.md` - Added "Stale Issue/PR Policy" section
- `CLAUDE.md` - Documented stale workflow in CI/CD section

## Configuration

**Issues:**
- 60 days inactive → marked stale
- 7 days after stale → closed
- Exempt labels: `keep-open`, `pinned`, `security`, `good-first-issue`, `help-wanted`, `enhancement`, `bug`

**Pull Requests:**
- 30 days inactive → marked stale
- 7 days after stale → closed
- Exempt labels: `keep-open`, `pinned`, `security`, `work in progress`, `work-in-progress`, `wip`

## Testing

**Manual Testing:**
- ✅ Workflow file validates successfully (check-jsonschema)
- ✅ YAML linting passes (yamllint)
- ✅ GitHub Actions workflow schema validation passes
- ✅ Labels created successfully
- ✅ Documentation updated and formatted correctly
- ✅ Pre-commit hooks pass (all 67 hooks)

**Production Testing:**
- Workflow will run daily starting after merge
- Can be manually triggered via GitHub Actions UI
- Monitor first few runs to ensure proper behavior
- Adjust timeframes if needed based on results

## Acceptance Criteria

- [x] Workflow file created: `.github/workflows/stale.yml`
- [x] Scheduled to run daily (1 AM UTC)
- [x] Issues marked stale after 60 days
- [x] PRs marked stale after 30 days
- [x] Items closed 7 days after stale
- [x] Helpful messages posted (clear instructions)
- [x] `keep-open` label exempts items
- [x] Important labels exempt items (security, etc.)
- [x] Stale label removed when updated
- [x] Manual trigger available (workflow_dispatch)
- [x] Required labels created
- [x] CONTRIBUTING.md updated (stale policy section)
- [x] CLAUDE.md updated (CI/CD section)
- [x] Workflow validated (schema, YAML linting)

## Documentation

**CONTRIBUTING.md:**
- Added new section: "Stale Issue/PR Policy"
- Explains timeframes (60 days for issues, 30 days for PRs)
- Documents how to prevent closure (`keep-open` label, comments)
- Notes that closed items can be reopened

**CLAUDE.md:**
- Added subsection under "CI/CD": "Stale Issue/PR Management"
- Documents configuration, timeframes, labels, and rationale
- Explains exempt labels and reopening process

## Breaking Changes

None - This is a new workflow with no impact on existing functionality.

## Migration Required

None - Labels are created, workflow is ready to run immediately.

## Notes

**First Run:**
- Workflow will process existing issues/PRs on first run
- Review items marked stale to ensure no false positives
- Adjust exempt labels if needed
- Can add `keep-open` label to important items preemptively

**Monitoring:**
- Monitor stale items: `gh issue list --label stale`
- Monitor auto-closed items: `gh issue list --label closed-by-bot`
- Review community feedback and adjust timeframes as needed