### PR TITLE
fix(docs): Use absolute URLs for images in README for PyPI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src=".github/logo.png" alt="NHL Scrabble Logo" width="256">
+  <img src="https://raw.githubusercontent.com/bdperkin/nhl-scrabble/main/.github/logo.png" alt="NHL Scrabble Logo" width="256">
 </p>
 
 <h1 align="center">NHL Scrabble Score Analyzer</h1>
@@ -19,7 +19,7 @@
 [![Type checked: mypy](https://img.shields.io/badge/type%20checked-mypy-blue.svg)](http://mypy-lang.org/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/bdperkin/nhl-scrabble/main.svg)](https://results.pre-commit.ci/latest/github/bdperkin/nhl-scrabble/main)
-[![interrogate](./interrogate_badge.svg)](https://interrogate.readthedocs.io/)
+[![interrogate](https://raw.githubusercontent.com/bdperkin/nhl-scrabble/main/interrogate_badge.svg)](https://interrogate.readthedocs.io/)
 
 <!-- Package Info -->
 


### PR DESCRIPTION
## Issue

The PyPI package page (https://pypi.org/project/nhl-scrabble/) displays broken images because README.md uses relative paths that work on GitHub but not on PyPI.

**Broken Images:**
- Logo: `.github/logo.png`
- Interrogate badge: `./interrogate_badge.svg`

## Solution

Changed relative paths to absolute GitHub raw URLs:

```diff
- <img src=".github/logo.png" alt="NHL Scrabble Logo" width="256">
+ <img src="https://raw.githubusercontent.com/bdperkin/nhl-scrabble/main/.github/logo.png" alt="NHL Scrabble Logo" width="256">

- [![interrogate](./interrogate_badge.svg)](https://interrogate.readthedocs.io/)
+ [![interrogate](https://raw.githubusercontent.com/bdperkin/nhl-scrabble/main/interrogate_badge.svg)](https://interrogate.readthedocs.io/)
```

## Testing

- ✅ Images still work on GitHub (absolute URLs compatible)
- ✅ Pre-commit hooks passed
- ⏳ Will fix PyPI page on next release

## Impact

**Low risk** - Documentation-only change that improves PyPI package page presentation.

**Before merge:**
- PyPI shows broken image placeholders

**After merge + release:**
- PyPI will display logo and interrogate badge correctly

## Notes

This fix will take effect on the next PyPI release (v0.0.5) since PyPI reads README.md from the published package, not from GitHub directly.