### PR TITLE
fix(config): Update PyPI Homepage to point to documentation site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,9 +175,11 @@ dev = [
 [project.scripts]
 nhl-scrabble = "nhl_scrabble.cli:cli"
 [project.urls]
-Homepage = "https://github.com/bdperkin/nhl-scrabble"
+Homepage = "https://bdperkin.github.io/nhl-scrabble/"
+Documentation = "https://bdperkin.github.io/nhl-scrabble/"
 Repository = "https://github.com/bdperkin/nhl-scrabble"
 Issues = "https://github.com/bdperkin/nhl-scrabble/issues"
+Changelog = "https://github.com/bdperkin/nhl-scrabble/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/nhl_scrabble/_version.py"


### PR DESCRIPTION
## Issue

The PyPI package page currently shows the GitHub repository as the "Homepage" link, but the documentation site at https://bdperkin.github.io/nhl-scrabble/ would be more useful for users discovering the package.

## Solution

Updated `[project.urls]` in pyproject.toml:

**Before:**
```toml
[project.urls]
Homepage = "https://github.com/bdperkin/nhl-scrabble"
Repository = "https://github.com/bdperkin/nhl-scrabble"
Issues = "https://github.com/bdperkin/nhl-scrabble/issues"
```

**After:**
```toml
[project.urls]
Homepage = "https://bdperkin.github.io/nhl-scrabble/"
Documentation = "https://bdperkin.github.io/nhl-scrabble/"
Repository = "https://github.com/bdperkin/nhl-scrabble"
Issues = "https://github.com/bdperkin/nhl-scrabble/issues"
Changelog = "https://github.com/bdperkin/nhl-scrabble/blob/main/CHANGELOG.md"
```

## PyPI Project Links (After Release)

The PyPI page will show these links in the sidebar:

- **Homepage** → Documentation site (new user-friendly landing)
- **Documentation** → Documentation site (explicit docs link)
- **Repository** → GitHub repo (for contributors)
- **Issues** → GitHub Issues (for bug reports)
- **Changelog** → CHANGELOG.md (release history)

## Benefits

- **Better UX:** New users see comprehensive documentation first
- **Clearer Separation:** Homepage = docs, Repository = code
- **More Links:** Added explicit Documentation and Changelog links
- **Standards:** Follows common PyPI package conventions

## Testing

- ✅ Pre-commit hooks passed (pyproject-fmt, validate-pyproject, check-wheel-contents)
- ✅ Configuration valid
- ⏳ Will appear on PyPI page on next release (v0.0.5)

## Impact

**Low risk** - Configuration-only change that improves package discoverability.

**Note:** This change will take effect on the next PyPI release since PyPI reads project metadata from the published package.