### PR TITLE
fix(ci): Make check-jsonschema non-blocking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,3 +261,13 @@ jobs:
         uses: pre-commit/action@v3.0.1
         env:
           UV_SYSTEM_PYTHON: "1"
+          # Skip check-jsonschema to run separately (non-blocking)
+          SKIP: check-jsonschema
+
+      - name: Run check-jsonschema (non-blocking)
+        run: |
+          uv pip install check-jsonschema --system
+          pre-commit run check-jsonschema --all-files
+        continue-on-error: true  # Don't block CI on network issues
+        env:
+          UV_SYSTEM_PYTHON: "1"


### PR DESCRIPTION
## Problem

The `check-jsonschema` pre-commit hook is fragile and frequently fails in CI due to network issues when downloading external JSON schemas (e.g., 503 errors from Codecov schema endpoints).

These network failures cause the entire **Pre-commit checks** job to fail, blocking PR merges even though the actual code is fine.

## Solution

Make `check-jsonschema` non-blocking in CI while keeping it active:
- Skip it in the main pre-commit run
- Run it separately with `continue-on-error: true`
- Still shows results but doesn't block the build

## Changes

**Modified**: `.github/workflows/ci.yml`
- Added `SKIP: check-jsonschema` to main pre-commit run
- Added separate step to run check-jsonschema with `continue-on-error: true`
- Explicitly install check-jsonschema for the separate step

## Benefits

✅ **Pre-commit checks won't fail** due to check-jsonschema network issues  
✅ **Hook still runs** - results visible in CI logs  
✅ **Local development unchanged** - hook runs normally in pre-commit  
✅ **Fragile external dependencies** don't block PRs  

## Behavior

**Before**:
- check-jsonschema runs in main pre-commit step
- Network errors (503, timeouts) fail entire Pre-commit checks job
- Blocks PR merging

**After**:
- check-jsonschema skipped in main pre-commit run
- Runs separately with `continue-on-error: true`
- Network errors show in logs but don't fail the build
- Other pre-commit hooks still block on failure (as they should)

**Local development**: No change - hook runs normally

## Testing

This PR will verify:
1. Pre-commit checks pass even if check-jsonschema fails
2. check-jsonschema still runs and shows output
3. Other hooks still fail the build when they should

## Trade-offs

**Acceptable**:
- check-jsonschema failures won't block PRs
- Developers must check logs to see if schemas are valid

**Mitigated by**:
- Hook still runs and shows results
- Failures visible in CI logs
- Can be run manually locally: `pre-commit run check-jsonschema --all-files`

## Related

Addresses recurring CI failures from fragile external schema downloads while maintaining schema validation coverage.
