### PR TITLE
fix(ci): Skip welcome workflow for repository owner and bots

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -15,6 +15,11 @@ jobs:
   welcome:
     name: Welcome New Contributor
     runs-on: ubuntu-latest
+    # Skip for repository owner and bots
+    if: |
+      github.actor != github.repository_owner &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'pre-commit-ci[bot]'
 
     steps:
       - name: Welcome first-time PR contributors


### PR DESCRIPTION
## Problem

The Welcome First-Time Contributors workflow appears in the checks list for every PR the repository owner creates, even though it doesn't do anything (because owner is not a first-time contributor).

This creates visual clutter in the checks and wastes workflow minutes.

## Solution

Add a job-level `if` condition to skip the workflow entirely when:
- The actor is the repository owner
- The actor is a bot (dependabot, pre-commit-ci)

## Changes

**Modified**: `.github/workflows/welcome.yml`
- Added job-level condition: `if: github.actor != github.repository_owner`
- Also skip for `dependabot[bot]` and `pre-commit-ci[bot]`
- Workflow won't even start for these actors

## Benefits

✅ **Cleaner checks list** for repository owner's PRs  
✅ **No wasted workflow runs** for owner/bots  
✅ **Still welcomes real first-time contributors** as intended  

## Behavior

**Before**:
- Workflow appeared in checks for every PR
- Ran but did nothing for owner's PRs (confusing)
- Wasted workflow minutes

**After**:
- Workflow skipped entirely for repository owner
- Won't appear in checks list for owner's PRs
- Still runs and welcomes actual first-time external contributors

## Testing

**This PR itself proves the fix works:**
- Check the workflow runs for this PR
- The "Welcome New Contributor" workflow should NOT appear in the checks
- If it doesn't appear, the fix is working! ✅

## Trade-offs

**None** - This is purely a UX improvement with no downsides.

## Related

Addresses unnecessary workflow runs for repository owner and bots.
