### PR TITLE
quality(qa): Remove commented-out code in performance conftest

### DIFF
--- a/qa/web/tests/performance/conftest.py
+++ b/qa/web/tests/performance/conftest.py
@@ -25,9 +25,6 @@ def performance_report_dir() -> Generator[Path, None, None]:
     yield report_dir
 
     # Cleanup is optional - keep reports for analysis
-    # Uncomment to clean up after tests:
-    # if report_dir.exists():
-    #     shutil.rmtree(report_dir)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Code Quality Finding

**Issue**: Closes #443
**Type**: CodeQL Alert #76
**Rule**: `py/commented-out-code`
**Severity**: Note (Low)
**Location**: `qa/web/tests/performance/conftest.py:29-30`

## Summary

Remove commented-out cleanup code identified by CodeQL. The code was intentionally disabled to preserve test reports for analysis, which is already clearly documented in the comment above.

## Changes

- **Removed**: Lines 29-30 containing commented-out `shutil.rmtree()` cleanup code
- **Kept**: Line 27-28 explanatory comment about optional cleanup
- **Impact**: No functional changes - purely code cleanup

**Before**:
```python
# Cleanup is optional - keep reports for analysis
# Uncomment to clean up after tests:
# if report_dir.exists():
#     shutil.rmtree(report_dir)
```

**After**:
```python
# Cleanup is optional - keep reports for analysis
```

## Rationale

Commented-out code can lead to:
- Code maintenance confusion
- Stale code accumulation
- Reduced code readability

Since the intent (keeping reports for analysis) is already clearly documented in the comment, the commented-out code is redundant.

## Testing

- ✅ Fixtures import successfully with no syntax errors
- ✅ No functional changes to test behavior
- ✅ Performance tests continue to preserve reports as intended
- ✅ All pre-commit hooks passed

## Code Quality Impact

**Before**: CodeQL alert #76 - commented-out code  
**After**: Alert will be resolved

**Risk**: None - This is a safe cleanup with no functional changes

## Verification

- [x] CodeQL alert addressed
- [x] No regression in test functionality
- [x] Intent clearly documented
- [x] Pre-commit hooks passed
- [x] No breaking changes