### PR TITLE
feat(web): Add missing page routes

### DIFF
--- a/src/nhl_scrabble/web/app.py
+++ b/src/nhl_scrabble/web/app.py
@@ -172,6 +172,121 @@ async def root(request: Request) -> HTMLResponse:
     )
 
 
+@app.get("/teams", response_class=HTMLResponse)
+async def teams_page(request: Request) -> HTMLResponse:
+    """Serve the teams standings page.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Rendered index.html template with teams view
+
+    Raises:
+        HTTPException: If templates not configured
+    """
+    if templates is None:
+        raise HTTPException(status_code=500, detail="Templates not configured")
+
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"view": "teams"},
+    )
+
+
+@app.get("/divisions", response_class=HTMLResponse)
+async def divisions_page(request: Request) -> HTMLResponse:
+    """Serve the divisions standings page.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Rendered index.html template with divisions view
+
+    Raises:
+        HTTPException: If templates not configured
+    """
+    if templates is None:
+        raise HTTPException(status_code=500, detail="Templates not configured")
+
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"view": "divisions"},
+    )
+
+
+@app.get("/conferences", response_class=HTMLResponse)
+async def conferences_page(request: Request) -> HTMLResponse:
+    """Serve the conferences standings page.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Rendered index.html template with conferences view
+
+    Raises:
+        HTTPException: If templates not configured
+    """
+    if templates is None:
+        raise HTTPException(status_code=500, detail="Templates not configured")
+
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"view": "conferences"},
+    )
+
+
+@app.get("/playoffs", response_class=HTMLResponse)
+async def playoffs_page(request: Request) -> HTMLResponse:
+    """Serve the playoff bracket page.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Rendered index.html template with playoffs view
+
+    Raises:
+        HTTPException: If templates not configured
+    """
+    if templates is None:
+        raise HTTPException(status_code=500, detail="Templates not configured")
+
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"view": "playoffs"},
+    )
+
+
+@app.get("/stats", response_class=HTMLResponse)
+async def stats_page(request: Request) -> HTMLResponse:
+    """Serve the statistics page.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Rendered index.html template with stats view
+
+    Raises:
+        HTTPException: If templates not configured
+    """
+    if templates is None:
+        raise HTTPException(status_code=500, detail="Templates not configured")
+
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"view": "stats"},
+    )
+
+
 @app.get("/favicon.svg")
 async def favicon() -> HTMLResponse:
     """Serve favicon as SVG.

--- a/tests/integration/test_web_routes.py
+++ b/tests/integration/test_web_routes.py
@@ -1,0 +1,150 @@
+"""Integration tests for web application routes.
+
+Tests that all page routes exist and return correct HTML responses.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nhl_scrabble.web.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client for FastAPI app.
+
+    Returns:
+        Test client instance
+    """
+    return TestClient(app)
+
+
+def test_root_route_exists(client: TestClient) -> None:
+    """Test / route returns HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_teams_route_exists(client: TestClient) -> None:
+    """Test /teams route returns HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    response = client.get("/teams")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_divisions_route_exists(client: TestClient) -> None:
+    """Test /divisions route returns HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    response = client.get("/divisions")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_conferences_route_exists(client: TestClient) -> None:
+    """Test /conferences route returns HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    response = client.get("/conferences")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_playoffs_route_exists(client: TestClient) -> None:
+    """Test /playoffs route returns HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    response = client.get("/playoffs")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_stats_route_exists(client: TestClient) -> None:
+    """Test /stats route returns HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    response = client.get("/stats")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_all_page_routes_exist(client: TestClient) -> None:
+    """Test all page routes return HTML.
+
+    Args:
+        client: FastAPI test client
+    """
+    routes = ["/", "/teams", "/divisions", "/conferences", "/playoffs", "/stats"]
+
+    for route in routes:
+        response = client.get(route)
+        assert response.status_code == 200, f"Route {route} failed"
+        assert "text/html" in response.headers["content-type"], f"Route {route} not HTML"
+        assert "<!DOCTYPE html>" in response.text, f"Route {route} missing DOCTYPE"
+
+
+def test_routes_have_view_context(client: TestClient) -> None:
+    """Test routes pass view context to template.
+
+    The view context should be accessible in the template for navigation highlighting.
+
+    Args:
+        client: FastAPI test client
+    """
+    # Note: Without inspecting the actual template rendering internals,
+    # we can't directly verify context variables. This test ensures the
+    # routes render successfully, which indirectly validates context handling.
+
+    routes_with_context = [
+        "/teams",
+        "/divisions",
+        "/conferences",
+        "/playoffs",
+        "/stats",
+    ]
+
+    for route in routes_with_context:
+        response = client.get(route)
+        assert response.status_code == 200
+        # Template rendering succeeded (would fail if context was malformed)
+        assert "<!DOCTYPE html>" in response.text
+
+
+def test_routes_not_returning_json_errors(client: TestClient) -> None:
+    """Test routes don't return JSON 404 errors.
+
+    Args:
+        client: FastAPI test client
+    """
+    routes = ["/teams", "/divisions", "/conferences", "/playoffs", "/stats"]
+
+    for route in routes:
+        response = client.get(route)
+        # Should not get JSON error response
+        assert '{"detail":"Not Found"}' not in response.text
+        assert "Not Found" not in response.text or "<!DOCTYPE html>" in response.text


### PR DESCRIPTION
## Task

**Task File**: `tasks/bug-fixes/015-missing-web-routes.md`
**GitHub Issue**: Closes #456
**Priority**: HIGH
**Estimated Effort**: 2-3 hours

## Summary

Add route handlers for teams, divisions, conferences, playoffs, and stats pages. These routes were referenced by visual regression tests and page objects but were missing from the FastAPI app, causing 404 errors.

## Changes

**Routes Added:**
- `/teams` - Team standings page
- `/divisions` - Division standings page
- `/conferences` - Conference standings page
- `/playoffs` - Playoff bracket page
- `/stats` - Statistics page

**Implementation:**
- All routes render `index.html` template (single-page app design)
- Each route passes view context parameter for navigation highlighting
- Added comprehensive integration tests

**Files Modified:**
- `src/nhl_scrabble/web/app.py` - Added 5 new route handlers
- `tests/integration/test_web_routes.py` - Added 9 integration tests

## Implementation Details

**Approach:** Single template with view context
- Renders same `index.html` template for all routes
- Passes `view` context variable ("teams", "divisions", etc.)
- Allows template to highlight active navigation item
- Maintains single-page app architecture

**Route Pattern:**
```python
@app.get("/teams", response_class=HTMLResponse)
async def teams_page(request: Request) -> HTMLResponse:
    if templates is None:
        raise HTTPException(status_code=500, detail="Templates not configured")
    
    return templates.TemplateResponse(
        request=request,
        name="index.html",
        context={"view": "teams"},
    )
```

## Testing

✅ **Unit/Integration Tests:**
- All 9 new integration tests pass
- Tests verify all routes return HTML (200 OK)
- Tests verify correct content-type (text/html)
- Tests verify HTML structure (<!DOCTYPE html>)
- Tests verify no JSON error responses

✅ **Pre-commit Hooks:**
- 68/69 hooks pass (safety skipped - optional dependency)
- Code formatting validated (black, ruff)
- Type checking passed (mypy, ty - non-blocking warnings)
- Documentation checked (interrogate, pydocstyle)
- Security scanned (bandit)

## Acceptance Criteria

- [x] `/teams` route exists and returns HTML (200 OK)
- [x] `/divisions` route exists and returns HTML (200 OK)
- [x] `/conferences` route exists and returns HTML (200 OK)
- [x] `/playoffs` route exists and returns HTML (200 OK)
- [x] `/stats` route exists and returns HTML (200 OK)
- [x] All routes render `index.html` template successfully
- [x] No JSON `{"detail": "Not Found"}` errors on these routes
- [x] Unit/integration tests added for new routes
- [x] Pre-commit hooks pass
- [ ] Visual regression tests pass (will verify in CI)
- [ ] Functional tests pass (will verify in CI)
- [x] No breaking changes to existing routes

## Visual Regression Tests Fixed

This PR should fix the following visual regression test failures:
- `teams-page-full`
- `divisions-page-full`
- `conferences-page-full`
- `playoffs-page-full`
- `stats-page-full`
- `teams-page-viewport`
- `teams-page-tablet`
- `teams-page-chromium`

## Documentation

- Comprehensive docstrings added to all route handlers
- Test documentation included
- No user-facing documentation changes needed (routes are internal)

## Breaking Changes

None - This is a purely additive change.

## Migration Required

None - New routes are immediately available after deployment.

## Performance Impact

Minimal - Routes use same template rendering as existing `/` route.

## Security Considerations

- Routes follow same security patterns as existing routes
- Security headers middleware applies to all routes
- CSP policy enforced
- Template injection protection via Jinja2
- No additional attack surface introduced
