### PR TITLE
Fix QA CSP waits and teams navigation

### DIFF
--- a/qa/web/pages/base_page.py
+++ b/qa/web/pages/base_page.py
@@ -75,8 +75,8 @@ class BasePage:
         else:
             # Wait for any URL change
             current_url = self.page.url
-            self.page.wait_for_function(
-                f'window.location.href !== "{current_url}"',
+            self.page.wait_for_url(
+                lambda target_url: str(target_url) != current_url,
                 timeout=timeout,
             )
 

--- a/qa/web/tests/functional/test_error_handling.py
+++ b/qa/web/tests/functional/test_error_handling.py
@@ -173,14 +173,12 @@ def test_results_replace_previous_results(page_fixture: Page) -> None:
     page_fixture.fill("#topPlayers", "5")
     page_fixture.click("#analyzeBtn")
 
-    # Wait for results to update with proper wait condition
-    page_fixture.wait_for_function(
-        "document.querySelectorAll('#playersTable tbody tr').length === 5",
-        timeout=30000,
-    )
+    # Wait for results to update without string-evaluated JavaScript, which violates CSP.
+    rows = page_fixture.locator("#playersTable tbody tr")
+    expect(rows).to_have_count(5, timeout=30000)
 
     # Count rows from second submission - should be different
-    rows_2 = page_fixture.locator("#playersTable tbody tr").count()
+    rows_2 = rows.count()
     assert rows_2 == 5, "Second submission should have 5 rows (replaced previous)"  # noqa: S101
 
 
@@ -303,17 +301,15 @@ def test_concurrent_submissions_handled(page_fixture: Page) -> None:
     page_fixture.fill("#topPlayers", "20")
     page_fixture.click("#analyzeBtn")  # Actually submit the second request
 
-    # Wait for results to update with proper wait condition
-    page_fixture.wait_for_function(
-        "document.querySelectorAll('#playersTable tbody tr').length === 20",
-        timeout=30000,
-    )
+    # Wait for results to update without string-evaluated JavaScript, which violates CSP.
+    rows = page_fixture.locator("#playersTable tbody tr")
+    expect(rows).to_have_count(20, timeout=30000)
 
     # Verify we got updated results (20 rows)
     results = page_fixture.locator("#results")
     expect(results).to_be_visible()
 
-    second_rows = page_fixture.locator("#playersTable tbody tr").count()
+    second_rows = rows.count()
     assert (
         second_rows == 20
     ), f"Second submission should have 20 rows, got {second_rows}"  # noqa: S101

--- a/src/nhl_scrabble/web/templates/base.html
+++ b/src/nhl_scrabble/web/templates/base.html
@@ -67,6 +67,21 @@
                                 <a href="/">Home</a>
                             </li>
                             <li>
+                                <a href="/teams">Teams</a>
+                            </li>
+                            <li>
+                                <a href="/divisions">Divisions</a>
+                            </li>
+                            <li>
+                                <a href="/conferences">Conferences</a>
+                            </li>
+                            <li>
+                                <a href="/playoffs">Playoffs</a>
+                            </li>
+                            <li>
+                                <a href="/stats">Stats</a>
+                            </li>
+                            <li>
                                 <a href="/docs">API Docs</a>
                             </li>
                             <li>


### PR DESCRIPTION
## Summary

Fixes #454.

This is a narrow QA-failure pass for the reported CSP and accessibility/navigation failures:

- Replaces the two string-based `page.wait_for_function(...)` result-count waits in `test_error_handling.py` with locator count assertions, avoiding `unsafe-eval` under the app CSP.
- Replaces the shared `BasePage.wait_for_url(None)` string-evaluated JavaScript wait with Playwright's URL predicate API.
- Adds the missing first-party standings routes (`/teams`, `/divisions`, `/conferences`, `/playoffs`, `/stats`) to the main nav so `/teams` has a reachable keyboard-focusable nav target and the page-object link checks line up with the rendered UI.

## Verification

- `python3 -m py_compile qa/web/tests/functional/test_error_handling.py qa/web/pages/base_page.py`
- `git diff --check`
- Focused QA pytest command attempted after installing local test deps in a temporary venv; blocked before browser execution because this worker does not have Playwright browsers installed:
  - `BrowserType.launch: Executable doesn't exist ... please run playwright install`

No private deployment, secrets, paid CI, account access, or production data used.