### PR TITLE
Fix web navigation links for standings routes

### DIFF
--- a/src/nhl_scrabble/web/templates/base.html
+++ b/src/nhl_scrabble/web/templates/base.html
@@ -67,6 +67,21 @@
                                 <a href="/">Home</a>
                             </li>
                             <li>
+                                <a href="/teams">Teams</a>
+                            </li>
+                            <li>
+                                <a href="/divisions">Divisions</a>
+                            </li>
+                            <li>
+                                <a href="/conferences">Conferences</a>
+                            </li>
+                            <li>
+                                <a href="/playoffs">Playoffs</a>
+                            </li>
+                            <li>
+                                <a href="/stats">Stats</a>
+                            </li>
+                            <li>
                                 <a href="/docs">API Docs</a>
                             </li>
                             <li>


### PR DESCRIPTION
## Summary

Rescues the still-valuable navigation-only portion from #460 after #461 covered the CSP test fixes.

Fixes #454 by adding first-party navigation links for the routes that already exist:

- `/teams`
- `/divisions`
- `/conferences`
- `/playoffs`
- `/stats`

Context: maintainer review on #460 approved the approach and specifically called out these nav links as the unique remaining contribution after #461 merged.

## Verification

- Static assertion that all five expected anchors are present in `base.html`
- `git diff --check`
- `python3 -m py_compile qa/web/pages/base_page.py qa/web/tests/functional/test_navigation.py qa/web/tests/accessibility/test_keyboard_navigation.py`

No private deployment, secrets, paid CI, account access, or production data used.