### PR TITLE
fix(deps): Add requests-cache to Docker and QA dependencies

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -36,7 +36,8 @@ RUN pip install --no-cache-dir \
     pytest-html>=4.2 \
     pytest-playwright>=0.7.2 \
     pytest-playwright-snapshot>=1 \
-    pytest-xdist>=3.8
+    pytest-xdist>=3.8 \
+    requests-cache>=1.3.1
 
 # Install system dependencies for browsers (requires root)
 # This installs all OS packages needed for chromium, firefox, and webkit

--- a/qa/web/pyproject.toml
+++ b/qa/web/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
   "pytest-playwright>=0.7.2",
   "pytest-playwright-snapshot>=1", # Visual regression testing
   "pytest-xdist>=3.8",
+  "requests-cache>=1.3.1",         # HTTP request caching for NHL API
 ]
 # ============================================================================
 # Development Dependencies (optional)


### PR DESCRIPTION
## Summary

Add `requests-cache>=1.3.1` as a dependency alongside `platformdirs` in Docker and QA test configurations.

## Changes

- **.docker/Dockerfile**: Added `requests-cache>=1.3.1` to pip install
- **qa/web/pyproject.toml**: Added `requests-cache>=1.3.1` to dependencies

## Problem

PR #479 added `platformdirs>=4.0.0` to the Docker image and QA package, but missed adding `requests-cache>=1.3.1` which is a companion dependency used by the main package for NHL API caching. This caused:

1. Visual regression tests failing with `ModuleNotFoundError: No module named 'platformdirs'` (because the cache library imports platformdirs)
2. Flaky test failures in `test_api_analyze_post` with `sqlite3.OperationalError: no such table: responses` due to incomplete cache initialization

## Solution

Ensure `requests-cache` is available everywhere `platformdirs` is declared:
- ✅ `pyproject.toml` (main package) - already has both
- ✅ `scripts/pytest-playwright` - already has both  
- ✅ `.docker/Dockerfile` - now has both
- ✅ `qa/web/pyproject.toml` - now has both

## Testing

This fix will allow:
- Visual regression tests to pass (resolves platformdirs import error)
- QA automation tests to pass (resolves cache initialization)
- Eliminates flaky test failures from cache race conditions

## Related

- Fixes visual/QA test failures from PR #479
- Addresses flaky `test_api_analyze_post` sqlite cache errors