### PR TITLE
fix(deps): Add unidecode to Docker and QA dependencies

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -37,7 +37,8 @@ RUN pip install --no-cache-dir \
     pytest-playwright>=0.7.2 \
     pytest-playwright-snapshot>=1 \
     pytest-xdist>=3.8 \
-    requests-cache>=1.3.1
+    requests-cache>=1.3.1 \
+    unidecode>=1.3.0
 
 # Install system dependencies for browsers (requires root)
 # This installs all OS packages needed for chromium, firefox, and webkit

--- a/qa/web/pyproject.toml
+++ b/qa/web/pyproject.toml
@@ -93,6 +93,7 @@ dependencies = [
   "pytest-playwright-snapshot>=1", # Visual regression testing
   "pytest-xdist>=3.8",
   "requests-cache>=1.3.1",         # HTTP request caching for NHL API
+  "unidecode>=1.3",                # ASCII transliteration for player names
 ]
 # ============================================================================
 # Development Dependencies (optional)


### PR DESCRIPTION
## Summary

Add `unidecode>=1.3.0` to Docker image and QA package dependencies to complete the dependency consistency requirements for NHL API data processing and visual regression testing.

## Changes

**Modified files:**
- `.docker/Dockerfile`: Added `unidecode>=1.3.0` at line 41
- `qa/web/pyproject.toml`: Added `unidecode>=1.3` at line 96 (formatted by pyproject-fmt)

**Already present:**
- `pyproject.toml`: Already has `unidecode>=1.3.0`
- `scripts/pytest-playwright`: Already has `unidecode` in INSTALL_CMD

## Context

This completes the dependency trio (platformdirs, requests-cache, unidecode) required for:
- NHL API HTTP request caching
- ASCII transliteration for player names
- Visual regression testing with mocked fixtures

Related PRs:
- #479 - Added platformdirs dependency
- #480 - Added requests-cache dependency
- This PR - Adds unidecode dependency

## Testing

CI will validate the changes. Visual Regression and QA Automation tests are expected to fail due to outdated Docker image in GHCR (requires rebuild with these dependencies).

## Next Steps

After merge, the Docker image can be rebuilt with all three dependencies, which will resolve Visual/QA test failures in CI.