### PR TITLE
fix(docker): include hatch_build.py in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,8 +69,9 @@ Thumbs.db
 tasks/
 TASK-*.md
 
-# Scripts (not needed in container)
+# Scripts (not needed in container, except hatch_build.py for i18n compilation)
 scripts/
+!scripts/hatch_build.py
 
 # Templates
 templates/


### PR DESCRIPTION
## Problem

The Docker Build and Publish workflow is failing on main branch with:

```
OSError: Build script does not exist: scripts/hatch_build.py
```

## Root Cause

When we moved `hatch_build.py` from the project root to `scripts/` directory in PR #502, we didn't account for the fact that `.dockerignore` excludes the entire `scripts/` directory from Docker builds.

The `hatch_build.py` script is a custom Hatchling build hook that compiles .po translation files to .mo files during package installation. This is essential for the i18n functionality added in PR #502.

## Solution

Add an exception to `.dockerignore` to include `scripts/hatch_build.py` while still excluding other scripts that aren't needed in the Docker image.

```diff
-# Scripts (not needed in container)
-scripts/
+# Scripts (not needed in container, except hatch_build.py for i18n compilation)
+scripts/
+!scripts/hatch_build.py
```

## Testing

This fix will be validated when the Docker Build and Publish workflow runs on this PR.

## Related

- Fixes workflow failure introduced in PR #502
- Related to task #021 (Web Interface Internationalization)