### PR TITLE
Security: Update urllib3 to 2.7.0 (CVE-2026-44432)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
     "rich>=15.0.0",
     "starlette>=1.0.0",
     "unidecode>=1.3.0",
+    "urllib3>=2.7.0",
     "uvicorn[standard]>=0.27.0",
 ]
 [[project.authors]]
@@ -612,6 +613,7 @@ DEP002 = [
     "flask-babel",
     "locust",
     "pytest-playwright",
+    "urllib3",           # Security pin to enforce CVE-2026-44432 fix (decompression-bomb bypass)
 ]
 
 [tool.pyproject-fmt]

--- a/uv.lock
+++ b/uv.lock
@@ -1764,6 +1764,7 @@ dependencies = [
     { name = "rich" },
     { name = "starlette" },
     { name = "unidecode" },
+    { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2026,6 +2027,7 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260408" },
     { name = "types-requests", marker = "extra == 'type'", specifier = ">=2.33.0.20260408" },
     { name = "unidecode", specifier = ">=1.3.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
 ]
 provides-extras = ["branding", "build", "dev", "docs", "docs-gen", "export", "i18n", "lint", "publish", "qa", "security", "shell", "test", "tox", "type", "watch"]
@@ -4023,11 +4025,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Security Finding

**Issue**: Closes #570
**Type**: Dependabot
**Severity**: HIGH
**CVE**: CVE-2026-44432
**GHSA**: GHSA-mf9v-mfxr-j63j

## Summary

Update urllib3 from 2.6.3 to 2.7.0 to address a HIGH severity decompression-bomb vulnerability in the streaming API.

## Fix Implementation

urllib3's streaming API could decompress entire responses instead of requested portions in two cases:
1. Second `HTTPResponse.read(amt=N)` call with Brotli compression
2. `HTTPResponse.drain_conn()` after partial decompression

This could cause excessive resource consumption (CPU and memory) when processing highly compressed data from untrusted sources.

urllib3 2.7.0 fixes both issues by:
- Improving Brotli streaming efficiency
- Skipping decompression for `drain_conn()`

## Changes

- Added `urllib3>=2.7.0` to direct dependencies in `pyproject.toml`
- Updated `uv.lock` to urllib3 2.7.0
- Configured deptry to allow urllib3 as security pin (DEP002 ignore)
- All tests pass with new version (1847 passed)

## Security Impact

**Before**: Applications using urllib3 2.6.x streaming API could be vulnerable to decompression-bomb attacks causing excessive resource consumption (CWE-409)

**After**: urllib3 2.7.0 prevents decompression bombs in streaming API

**Risk Reduced**: Denial of service via decompression-bomb attacks

## Testing

- ✅ All existing tests pass (1847 passed, 15 skipped)
- ✅ No breaking changes detected
- ✅ Ruff linting passes
- ✅ Coverage maintained at 86.56%

## Verification

- [x] Vulnerability is resolved (urllib3 2.7.0)
- [x] No regression in functionality (all tests pass)
- [x] Documentation updated (deptry configuration)
- [x] Security advisory reviewed
- [x] No breaking changes

## References

- Dependabot Alert: https://github.com/bdperkin/nhl-scrabble/security/dependabot/2
- CVE: CVE-2026-44432
- GHSA: https://github.com/advisories/GHSA-mf9v-mfxr-j63j
- urllib3 Release: https://github.com/urllib3/urllib3/releases/tag/2.7.0