### PR TITLE
Security: Fix CodeQL 'Statement has no effect' warnings in Protocol methods

### DIFF
--- a/src/nhl_scrabble/interfaces.py
+++ b/src/nhl_scrabble/interfaces.py
@@ -74,7 +74,7 @@ class APIClientProtocol(Protocol):
         Raises:
             NHLApiError: If unable to fetch teams data
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def get_team_roster(
         self,
@@ -95,14 +95,14 @@ class APIClientProtocol(Protocol):
             NHLApiNotFoundError: If roster is not found (404 response)
             NHLApiError: For other API errors
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def clear_cache(self) -> None:
         """Clear the HTTP cache.
 
         Clears all cached API responses, forcing fresh fetches on next requests.
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def close(self) -> None:
         """Close the client session and release resources.
@@ -110,7 +110,7 @@ class APIClientProtocol(Protocol):
         Should be called when the client is no longer needed to properly clean up network
         connections and resources.
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def __enter__(self) -> APIClientProtocol:
         """Enter context manager - returns self.
@@ -125,7 +125,7 @@ class APIClientProtocol(Protocol):
             ...     teams = client.get_teams()
             ...     # Session automatically closed on exit
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def __exit__(
         self,
@@ -143,7 +143,7 @@ class APIClientProtocol(Protocol):
             exc_val: Exception value if an exception was raised, None otherwise
             exc_tb: Exception traceback if an exception was raised, None otherwise
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
 
 @runtime_checkable
@@ -186,7 +186,7 @@ class ScorerProtocol(Protocol):
             >>> scorer.score_player(player, "EDM", "Pacific", "Western", position_category="forwards")
             PlayerScore(first_name="Connor", last_name="McDavid", full_score=24, position_type="Forward", ...)
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
 
 @runtime_checkable
@@ -228,7 +228,7 @@ class TeamProcessorProtocol(Protocol):
             >>> len(teams_2022) > 0
             True
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def calculate_division_standings(
         self,
@@ -247,7 +247,7 @@ class TeamProcessorProtocol(Protocol):
             >>> "Atlantic" in standings
             True
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
     def calculate_conference_standings(
         self,
@@ -266,4 +266,4 @@ class TeamProcessorProtocol(Protocol):
             >>> "Eastern" in standings
             True
         """
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover


### PR DESCRIPTION
## Summary

Fixes all 10 CodeQL **'Statement has no effect'** warnings (alerts #197-206) by replacing ellipsis () with explicit  in Protocol method bodies.

## Changes

**Updated Protocol Methods:**
- `APIClientProtocol`: 6 methods
  - `get_teams()`
  - `get_team_roster()`
  - `clear_cache()`
  - `close()`
  - `__enter__()`
  - `__exit__()`
- `ScorerProtocol`: 1 method
  - `score_player()`
- `TeamProcessorProtocol`: 3 methods
  - `process_all_teams()`
  - `calculate_division_standings()`
  - `calculate_conference_standings()`

## Rationale

While `...` is the standard Python idiom for Protocol method placeholders (PEP 544), CodeQL flags these as ineffectual statements. Using `raise NotImplementedError` instead:

1. **Resolves CodeQL warnings** - Eliminates all 10 security alerts
2. **Clearer intent** - Makes it explicit that Protocol methods shouldn't be called directly
3. **Better error messages** - If accidentally invoked, provides informative runtime error
4. **Maintains Protocol semantics** - No impact on type checking or Protocol implementation

## Testing

- ✅ All interface tests pass (20/20)
- ✅ No behavioral changes to Protocol implementations
- ✅ Type checking still works correctly
- ✅ All pre-commit hooks pass

## Security Impact

**CodeQL Alerts Resolved:**
- #197 - `get_teams()` at line 77
- #198 - `get_team_roster()` at line 98
- #199 - `clear_cache()` at line 105
- #200 - `close()` at line 113
- #201 - `__enter__()` at line 128
- #202 - `__exit__()` at line 146
- #203 - `score_player()` at line 189
- #204 - `process_all_teams()` at line 231
- #205 - `calculate_division_standings()` at line 250
- #206 - `calculate_conference_standings()` at line 269

This change improves code quality and eliminates false-positive security warnings without affecting functionality.