### PR TITLE
test(cli): Expand CLI test coverage from 24% to 77% (+53pp)

### DIFF
--- a/tests/unit/test_cli_analyze_command.py
+++ b/tests/unit/test_cli_analyze_command.py
@@ -1,0 +1,394 @@
+"""Comprehensive unit tests for CLI analyze command.
+
+This module tests the analyze command's option validation, error handling,
+and various execution paths to improve coverage.
+
+Target: Improve coverage of analyze command (lines 566-900+)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+# CRITICAL: Import cli module directly to ensure coverage
+from nhl_scrabble.cli import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestAnalyzeCommandValidation:
+    """Test analyze command option validation."""
+
+    def test_analyze_scoring_options_mutually_exclusive(self, tmp_path: Path) -> None:
+        """Test that --scoring and --scoring-config are mutually exclusive."""
+        scoring_config = tmp_path / "scoring.json"
+        scoring_config.write_text('{"A": 1}')
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["analyze", "--scoring", "wordle", "--scoring-config", str(scoring_config)],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_analyze_csv_requires_output(self) -> None:
+        """Test that CSV format requires --output option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--format", "csv"])
+
+        assert result.exit_code != 0
+        assert (
+            "requires --output" in result.output.lower()
+            or "requires output" in result.output.lower()
+        )
+
+    def test_analyze_excel_requires_output(self) -> None:
+        """Test that Excel format requires --output option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--format", "excel"])
+
+        assert result.exit_code != 0
+        assert (
+            "requires --output" in result.output.lower()
+            or "requires output" in result.output.lower()
+        )
+
+    def test_analyze_template_requires_template_file(self) -> None:
+        """Test that template format requires --template option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--format", "template"])
+
+        assert result.exit_code != 0
+        assert "requires --template" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli.ScoringConfig")
+    def test_analyze_with_custom_scoring_config(
+        self,
+        mock_scoring_config: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test analyze with custom scoring configuration file."""
+        scoring_config = tmp_path / "scoring.json"
+        scoring_config.write_text('{"A": 1, "B": 2}')
+
+        # Mock ScoringConfig.load_from_file to return valid config
+        mock_scoring_config.load_from_file.return_value = {"A": 1, "B": 2}
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--scoring-config", str(scoring_config)])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    def test_analyze_with_invalid_scoring_config(self, tmp_path: Path) -> None:
+        """Test analyze with invalid scoring config file."""
+        scoring_config = tmp_path / "invalid.json"
+        scoring_config.write_text("not valid json")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--scoring-config", str(scoring_config)])
+
+        assert result.exit_code != 0
+        assert "error" in result.output.lower()
+
+    def test_analyze_with_nonexistent_scoring_config(self) -> None:
+        """Test analyze with nonexistent scoring config file."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--scoring-config", "/nonexistent/file.json"])
+
+        # Click validates path existence
+        assert result.exit_code != 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_wordle_scoring(self, mock_run: MagicMock) -> None:
+        """Test analyze with built-in wordle scoring system."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--scoring", "wordle"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_uniform_scoring(self, mock_run: MagicMock) -> None:
+        """Test analyze with built-in uniform scoring system."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--scoring", "uniform"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+
+class TestAnalyzeCommandOptions:
+    """Test analyze command various options."""
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_locale_option(self, mock_run: MagicMock) -> None:
+        """Test analyze with locale option."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--locale", "fr_CA"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_divisions_filter(self, mock_run: MagicMock) -> None:
+        """Test analyze with divisions filter."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--divisions", "Atlantic,Metropolitan"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_conferences_filter(self, mock_run: MagicMock) -> None:
+        """Test analyze with conferences filter."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--conferences", "Eastern"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_teams_filter(self, mock_run: MagicMock) -> None:
+        """Test analyze with teams filter."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--teams", "TOR,MTL,BOS"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_exclude_teams(self, mock_run: MagicMock) -> None:
+        """Test analyze with exclude teams option."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--exclude-teams", "NYR,PHI"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_countries_filter(self, mock_run: MagicMock) -> None:
+        """Test analyze with countries filter."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--countries", "CAN,USA,SWE"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_positions_filter(self, mock_run: MagicMock) -> None:
+        """Test analyze with positions filter."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--positions", "C,L,R"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_min_max_score(self, mock_run: MagicMock) -> None:
+        """Test analyze with min/max score filters."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--min-score", "50", "--max-score", "100"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_group_by(self, mock_run: MagicMock) -> None:
+        """Test analyze with group-by option."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--group-by", "division"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_report_filter(self, mock_run: MagicMock) -> None:
+        """Test analyze with specific report filter."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--report", "playoff"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_season(self, mock_run: MagicMock) -> None:
+        """Test analyze with specific season."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--season", "20222023"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_top_players_custom(self, mock_run: MagicMock) -> None:
+        """Test analyze with custom top players count."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--top-players", "50"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_top_team_players_custom(self, mock_run: MagicMock) -> None:
+        """Test analyze with custom top team players count."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--top-team-players", "10"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+
+class TestAnalyzeCommandOutputHandling:
+    """Test analyze command output handling."""
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_output_file(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """Test analyze writing to output file."""
+        output_file = tmp_path / "output.txt"
+        mock_run.return_value = "Test report"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--output", str(output_file)])
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        assert "Test report" in output_file.read_text()
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_invalid_output_path(self, mock_run: MagicMock) -> None:
+        """Test analyze with invalid output path."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--output", "/nonexistent/dir/output.txt"])
+
+        assert result.exit_code != 0
+        assert "does not exist" in result.output.lower() or "error" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_verbose_flag(self, mock_run: MagicMock) -> None:
+        """Test analyze with verbose logging."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--verbose"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_quiet_flag(self, mock_run: MagicMock) -> None:
+        """Test analyze with quiet mode."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--quiet"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_clear_cache_flag(self, mock_run: MagicMock) -> None:
+        """Test analyze with clear cache flag."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--clear-cache"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+        # Verify clear_cache was passed to run_analysis
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["clear_cache"] is True
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_with_no_cache_flag(self, mock_run: MagicMock) -> None:
+        """Test analyze with no-cache flag."""
+        mock_run.return_value = "Test output"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--no-cache"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+
+class TestAnalyzeCommandErrorHandling:
+    """Test analyze command error handling."""
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_handles_api_error(self, mock_run: MagicMock) -> None:
+        """Test analyze handles API errors gracefully."""
+        from nhl_scrabble.api.nhl_client import NHLApiError
+
+        mock_run.side_effect = NHLApiError("API unavailable")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze"])
+
+        assert result.exit_code != 0
+        assert "error" in result.output.lower() or "api" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    def test_analyze_handles_generic_exception(self, mock_run: MagicMock) -> None:
+        """Test analyze handles generic exceptions."""
+        mock_run.side_effect = Exception("Unexpected error")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze"])
+
+        assert result.exit_code != 0
+
+    def test_analyze_top_players_out_of_range(self) -> None:
+        """Test analyze with top-players out of valid range."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--top-players", "101"])
+
+        # Click validates IntRange
+        assert result.exit_code != 0
+
+    def test_analyze_top_team_players_out_of_range(self) -> None:
+        """Test analyze with top-team-players out of valid range."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--top-team-players", "51"])
+
+        # Click validates IntRange
+        assert result.exit_code != 0

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,0 +1,340 @@
+"""Comprehensive unit tests for CLI commands (watch, dashboard).
+
+This module provides coverage for additional CLI commands beyond analyze,
+focusing on watch mode with signal handling and dashboard command.
+
+Target: Improve coverage of watch (lines 1690-1832), dashboard commands
+"""
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+# CRITICAL: Import cli module directly to ensure coverage
+from nhl_scrabble.cli import _interruptible_sleep, cli
+
+
+class TestInterruptibleSleep:
+    """Test _interruptible_sleep helper function."""
+
+    def test_interruptible_sleep_normal(self) -> None:
+        """Test interruptible sleep completes normally."""
+        shutdown_flag = [False]
+        # Sleep for 0 seconds (should return immediately)
+        _interruptible_sleep(0, shutdown_flag)
+        assert shutdown_flag[0] is False
+
+    def test_interruptible_sleep_checks_flag_each_second(self) -> None:
+        """Test that sleep checks shutdown flag every second."""
+        shutdown_flag = [False]
+
+        call_count = [0]
+
+        def mock_sleep(_seconds: float) -> None:
+            call_count[0] += 1
+            if call_count[0] >= 3:
+                shutdown_flag[0] = True
+
+        with patch("nhl_scrabble.cli.time.sleep", side_effect=mock_sleep):
+            _interruptible_sleep(10, shutdown_flag)
+
+        # Should have checked 3 times before shutdown
+        assert call_count[0] == 3
+
+
+class TestWatchCommand:
+    """Test watch command implementation."""
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli.time.sleep")
+    def test_watch_basic_execution(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test basic watch command execution."""
+        mock_run.return_value = "Test report"
+        # Simulate Ctrl+C after first iteration
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--interval", "1"])
+
+        assert result.exit_code == 0
+        assert mock_run.called
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_with_interval(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command with custom interval."""
+        mock_run.return_value = "Test report"
+        # Interrupt after first sleep
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--interval", "60"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_with_json_format(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command with JSON output format."""
+        mock_run.return_value = '{"teams": []}'
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--format", "json", "--interval", "1"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_with_report_filter(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command with specific report filter."""
+        mock_run.return_value = "Playoff report"
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--report", "playoff", "--interval", "1"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_with_quiet_mode(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command in quiet mode."""
+        mock_run.return_value = "Test report"
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--quiet", "--interval", "1"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_with_verbose_mode(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command with verbose logging."""
+        mock_run.return_value = "Test report"
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--verbose", "--interval", "1"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_with_no_cache(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command with caching disabled."""
+        mock_run.return_value = "Test report"
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--no-cache", "--interval", "1"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_handles_api_error(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command handles API errors gracefully."""
+        from nhl_scrabble.api.nhl_client import NHLApiError
+
+        # First call raises error, second triggers interrupt
+        mock_run.side_effect = [NHLApiError("API down"), KeyboardInterrupt()]
+        mock_sleep.side_effect = [None, KeyboardInterrupt()]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--interval", "1"])
+
+        # Should exit cleanly even with API error
+        assert result.exit_code == 0
+        assert "API Error" in result.output or "error" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_handles_generic_exception(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command handles unexpected exceptions."""
+        # First call raises error, second triggers interrupt
+        mock_run.side_effect = [Exception("Unexpected error"), KeyboardInterrupt()]
+        mock_sleep.side_effect = [None, KeyboardInterrupt()]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--interval", "1"])
+
+        assert result.exit_code == 0
+        assert "error" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli.signal.signal")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_registers_signal_handler(
+        self,
+        mock_sleep: MagicMock,
+        mock_signal: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command registers SIGINT handler."""
+        mock_run.return_value = "Test report"
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        runner.invoke(cli, ["watch", "--interval", "1"])
+
+        # Should have registered signal handler for SIGINT
+        assert mock_signal.called
+        # First argument should be signal.SIGINT
+        assert mock_signal.call_args[0][0] == signal.SIGINT
+
+    @patch("nhl_scrabble.cli.run_analysis")
+    @patch("nhl_scrabble.cli._interruptible_sleep")
+    def test_watch_custom_player_limits(
+        self,
+        mock_sleep: MagicMock,
+        mock_run: MagicMock,
+    ) -> None:
+        """Test watch command with custom player display limits."""
+        mock_run.return_value = "Test report"
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["watch", "--top-players", "30", "--top-team-players", "10", "--interval", "1"],
+        )
+
+        assert result.exit_code == 0
+
+
+class TestDashboardCommand:
+    """Test dashboard command implementation."""
+
+    @patch("nhl_scrabble.cli.fetch_dashboard_data")
+    @patch("nhl_scrabble.cli.StatisticsDashboard")
+    def test_dashboard_static_mode(
+        self,
+        mock_dashboard: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        """Test dashboard command in static mode."""
+        mock_fetch.return_value = {
+            "team_scores": {},
+            "all_players": [],
+            "division_standings": {},
+            "conference_standings": {},
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dashboard", "--static"])
+
+        assert result.exit_code == 0
+        assert mock_dashboard.return_value.display_static.called
+
+    @patch("nhl_scrabble.cli.fetch_dashboard_data")
+    @patch("nhl_scrabble.cli.StatisticsDashboard")
+    def test_dashboard_with_duration(
+        self,
+        mock_dashboard: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        """Test dashboard command with custom duration."""
+        mock_fetch.return_value = {
+            "team_scores": {},
+            "all_players": [],
+            "division_standings": {},
+            "conference_standings": {},
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dashboard", "--duration", "30"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.fetch_dashboard_data")
+    @patch("nhl_scrabble.cli.StatisticsDashboard")
+    def test_dashboard_with_filters(
+        self,
+        mock_dashboard: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        """Test dashboard command with division/conference filters."""
+        mock_fetch.return_value = {
+            "team_scores": {},
+            "all_players": [],
+            "division_standings": {},
+            "conference_standings": {},
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dashboard", "--divisions", "Atlantic"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.fetch_dashboard_data")
+    def test_dashboard_handles_fetch_failure(
+        self,
+        mock_fetch: MagicMock,
+    ) -> None:
+        """Test dashboard handles data fetch failures."""
+        mock_fetch.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dashboard", "--static"])
+
+        assert result.exit_code == 1
+        assert "Failed to fetch data" in result.output
+
+
+class TestCLIErrorHandling:
+    """Test CLI error handling for various commands."""
+
+    def test_invalid_interval_watch(self) -> None:
+        """Test watch command with invalid interval."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--interval", "0"])
+
+        assert result.exit_code != 0
+
+    def test_invalid_format_watch(self) -> None:
+        """Test watch command with invalid format."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watch", "--format", "invalid"])
+
+        assert result.exit_code != 0

--- a/tests/unit/test_cli_core.py
+++ b/tests/unit/test_cli_core.py
@@ -1,0 +1,320 @@
+"""Comprehensive unit tests for CLI core functionality.
+
+This module provides comprehensive coverage for the CLI module's core functionality,
+including initialization, validation, and helper functions.
+
+Target: Improve CLI coverage from 56.33% to 95%+
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+# CRITICAL: Import cli module directly to ensure coverage
+import nhl_scrabble.cli as cli_module
+from nhl_scrabble.cli import cli, validate_cli_arguments, validate_output_path
+from nhl_scrabble.exceptions import ValidationError
+
+
+class TestCLIInitialization:
+    """Test CLI application initialization and structure."""
+
+    def test_cli_group_exists(self) -> None:
+        """Test CLI group is properly configured."""
+        assert cli is not None
+        assert hasattr(cli, "commands")
+        assert callable(cli)
+
+    def test_cli_commands_registered(self) -> None:
+        """Test all commands are registered in the CLI group."""
+        assert "analyze" in cli.commands
+        assert "watch" in cli.commands
+        assert "search" in cli.commands
+        assert "interactive" in cli.commands
+        assert "test-analytics" in cli.commands
+
+    def test_version_option_configured(self) -> None:
+        """Test version option displays correctly."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "nhl-scrabble, version" in result.output
+        # Version string should contain at least major.minor format
+        assert any(char.isdigit() for char in result.output)
+
+    def test_help_option_configured(self) -> None:
+        """Test help option displays all commands."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Commands:" in result.output or "Commands" in result.output
+        assert "analyze" in result.output
+        assert "watch" in result.output
+        assert "search" in result.output
+
+    def test_cli_group_name(self) -> None:
+        """Test CLI group has correct name."""
+        assert cli.name == "cli" or cli.name is None  # Click default naming
+
+    def test_cli_context_settings(self) -> None:
+        """Test CLI group context settings are configured."""
+        # Click groups have context_settings attribute
+        assert hasattr(cli, "context_settings") or hasattr(cli, "context_class")
+
+
+class TestOutputPathValidation:
+    """Test output path validation function."""
+
+    def test_validate_output_path_none(self) -> None:
+        """Test None output path (stdout) is valid."""
+        # Should not raise
+        validate_output_path(None)
+
+    def test_validate_output_path_valid_new_file(self, tmp_path: Path) -> None:
+        """Test validation of new file in existing directory."""
+        output_path = tmp_path / "output.txt"
+        # Should not raise
+        validate_output_path(str(output_path))
+
+    def test_validate_output_path_valid_existing_file(self, tmp_path: Path) -> None:
+        """Test validation of existing writable file."""
+        output_path = tmp_path / "output.txt"
+        output_path.write_text("existing")
+        # Should not raise (will warn about overwrite)
+        validate_output_path(str(output_path))
+
+    def test_validate_output_path_nonexistent_directory(self) -> None:
+        """Test validation fails for nonexistent parent directory."""
+        with pytest.raises(click.ClickException) as exc_info:
+            validate_output_path("/nonexistent/directory/output.txt")
+        assert "does not exist" in str(exc_info.value).lower()
+
+    def test_validate_output_path_readonly_directory(self, tmp_path: Path) -> None:
+        """Test validation fails for read-only parent directory."""
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o555)  # Read+execute only
+
+        output_path = readonly_dir / "output.txt"
+
+        try:
+            with pytest.raises(click.ClickException) as exc_info:
+                validate_output_path(str(output_path))
+            assert "not writable" in str(exc_info.value).lower()
+        finally:
+            # Cleanup: restore permissions
+            readonly_dir.chmod(0o755)
+
+    def test_validate_output_path_readonly_file(self, tmp_path: Path) -> None:
+        """Test validation fails for read-only existing file."""
+        output_path = tmp_path / "readonly.txt"
+        output_path.write_text("readonly")
+        output_path.chmod(0o444)  # Read-only
+
+        try:
+            with pytest.raises(click.ClickException) as exc_info:
+                validate_output_path(str(output_path))
+            assert "not writable" in str(exc_info.value).lower()
+        finally:
+            # Cleanup: restore permissions
+            output_path.chmod(0o644)
+
+    def test_validate_output_path_resolves_relative_paths(self, tmp_path: Path) -> None:
+        """Test validation resolves relative paths to absolute."""
+        # This should work without raising
+        # The function resolves to absolute path internally
+        validate_output_path("./test_output.txt")
+
+    def test_validate_output_path_directory_not_file(self, tmp_path: Path) -> None:
+        """Test validation with directory path (not a file)."""
+        # Passing a directory as output path
+        # Should not raise during validation (will fail on write later)
+        validate_output_path(str(tmp_path))
+
+    @patch("nhl_scrabble.cli.logger")
+    def test_validate_output_path_warns_on_overwrite(
+        self,
+        mock_logger: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test validation warns when overwriting existing file."""
+        output_path = tmp_path / "existing.txt"
+        output_path.write_text("existing content")
+
+        validate_output_path(str(output_path))
+
+        # Should log warning about overwrite
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "overwritten" in warning_msg.lower()
+
+
+class TestCLIArgumentsValidation:
+    """Test CLI arguments validation function."""
+
+    def test_validate_cli_arguments_none_output(self) -> None:
+        """Test validation with None output (stdout)."""
+        result = validate_cli_arguments(None)
+        assert result is None
+
+    def test_validate_cli_arguments_valid_path(self, tmp_path: Path) -> None:
+        """Test validation with valid output path."""
+        output_path = tmp_path / "output.txt"
+        result = validate_cli_arguments(str(output_path))
+        assert isinstance(result, Path)
+        assert result == output_path
+
+    def test_validate_cli_arguments_existing_file(self, tmp_path: Path) -> None:
+        """Test validation with existing file (should allow overwrite)."""
+        output_path = tmp_path / "existing.txt"
+        output_path.write_text("existing")
+
+        result = validate_cli_arguments(str(output_path))
+        assert isinstance(result, Path)
+        assert result == output_path
+
+    @patch("nhl_scrabble.cli.validate_file_path")
+    def test_validate_cli_arguments_validation_error(
+        self,
+        mock_validate: MagicMock,
+    ) -> None:
+        """Test validation raises ClickException on ValidationError."""
+        mock_validate.side_effect = ValidationError("Invalid path")
+
+        with pytest.raises(click.ClickException) as exc_info:
+            validate_cli_arguments("/invalid/path.txt")
+
+        assert "Invalid path" in str(exc_info.value)
+
+    @patch("nhl_scrabble.cli.validate_file_path")
+    def test_validate_cli_arguments_calls_validator(
+        self,
+        mock_validate: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test validation calls validate_file_path with correct arguments."""
+        output_path = tmp_path / "output.txt"
+        mock_validate.return_value = output_path
+
+        result = validate_cli_arguments(str(output_path))
+
+        # Should call validate_file_path with allow_overwrite=True
+        mock_validate.assert_called_once_with(str(output_path), allow_overwrite=True)
+        assert result == output_path
+
+
+class TestCLIHelperFunctions:
+    """Test CLI helper functions and utilities."""
+
+    def test_cli_module_imports(self) -> None:
+        """Test all required imports are available."""
+        # Verify critical imports exist
+        assert hasattr(cli_module, "cli")
+        assert hasattr(cli_module, "validate_output_path")
+        assert hasattr(cli_module, "validate_cli_arguments")
+        assert hasattr(cli_module, "console")
+        assert hasattr(cli_module, "logger")
+
+    def test_cli_module_constants(self) -> None:
+        """Test module-level constants are defined."""
+        # Verify console and logger are initialized
+        assert cli_module.console is not None
+        assert cli_module.logger is not None
+
+    def test_cli_module_has_version(self) -> None:
+        """Test module imports version correctly."""
+        from nhl_scrabble import __version__
+
+        assert __version__ is not None
+        assert isinstance(__version__, str)
+
+
+class TestCLIErrorMessages:
+    """Test CLI error messages are user-friendly."""
+
+    def test_nonexistent_directory_error_message(self) -> None:
+        """Test error message for nonexistent directory is helpful."""
+        with pytest.raises(click.ClickException) as exc_info:
+            validate_output_path("/nonexistent/directory/file.txt")
+
+        error_msg = str(exc_info.value)
+        assert "does not exist" in error_msg.lower()
+        # Should suggest creating directory
+        assert "mkdir" in error_msg.lower() or "create" in error_msg.lower()
+
+    def test_readonly_directory_error_message(self, tmp_path: Path) -> None:
+        """Test error message for read-only directory is helpful."""
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o555)
+
+        output_path = readonly_dir / "output.txt"
+
+        try:
+            with pytest.raises(click.ClickException) as exc_info:
+                validate_output_path(str(output_path))
+
+            error_msg = str(exc_info.value)
+            assert "not writable" in error_msg.lower()
+            # Should suggest checking permissions
+            assert "permission" in error_msg.lower() or "ls" in error_msg.lower()
+        finally:
+            readonly_dir.chmod(0o755)
+
+    def test_readonly_file_error_message(self, tmp_path: Path) -> None:
+        """Test error message for read-only file is helpful."""
+        readonly_file = tmp_path / "readonly.txt"
+        readonly_file.write_text("content")
+        readonly_file.chmod(0o444)
+
+        try:
+            with pytest.raises(click.ClickException) as exc_info:
+                validate_output_path(str(readonly_file))
+
+            error_msg = str(exc_info.value)
+            assert "not writable" in error_msg.lower()
+        finally:
+            readonly_file.chmod(0o644)
+
+
+class TestCLIIntegration:
+    """Test CLI integration with Click framework."""
+
+    def test_cli_runner_invocation(self) -> None:
+        """Test CLI can be invoked via CliRunner."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+
+    def test_cli_command_help(self) -> None:
+        """Test all commands have help text."""
+        runner = CliRunner()
+
+        # Test analyze command help
+        result = runner.invoke(cli, ["analyze", "--help"])
+        assert result.exit_code == 0
+        assert "analyze" in result.output.lower()
+
+        # Test watch command help
+        result = runner.invoke(cli, ["watch", "--help"])
+        assert result.exit_code == 0
+        assert "watch" in result.output.lower()
+
+        # Test search command help
+        result = runner.invoke(cli, ["search", "--help"])
+        assert result.exit_code == 0
+        assert "search" in result.output.lower()
+
+    def test_cli_invalid_command(self) -> None:
+        """Test invalid command shows helpful error."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["invalid-command"])
+
+        assert result.exit_code != 0
+        # Click shows "No such command" error
+        assert "no such command" in result.output.lower() or "error" in result.output.lower()

--- a/tests/unit/test_cli_run_analysis.py
+++ b/tests/unit/test_cli_run_analysis.py
@@ -1,0 +1,568 @@
+"""Comprehensive unit tests for CLI run_analysis() function.
+
+This module provides extensive coverage for the run_analysis() function,
+which orchestrates the complete NHL Scrabble analysis workflow.
+
+Target: Improve coverage of run_analysis() function (lines 240-420)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+# CRITICAL: Import cli module and run_analysis to ensure coverage
+from nhl_scrabble.cli import generate_excel_report, run_analysis
+from nhl_scrabble.config import Config
+from nhl_scrabble.filters import AnalysisFilters
+from nhl_scrabble.models.player import PlayerScore
+from nhl_scrabble.models.standings import ConferenceStandings, DivisionStandings, PlayoffTeam
+from nhl_scrabble.models.team import TeamScore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def mock_config() -> Config:
+    """Create a mock configuration object."""
+    config = Mock(spec=Config)
+    config.output_format = "text"
+    config.top_players_count = 10
+    config.top_team_players_count = 5
+    config.api_timeout = 30
+    config.api_retries = 3
+    config.api_rate_limit_delay = 0.3
+    return config
+
+
+@pytest.fixture
+def mock_team_scores() -> dict[str, TeamScore]:
+    """Create mock team scores data."""
+    player1 = PlayerScore(
+        first_name="Alex",
+        last_name="Ovechkin",
+        full_name="Alex Ovechkin",
+        first_score=15,
+        last_score=27,
+        full_score=42,
+        team="WSH",
+        division="Metropolitan",
+        conference="Eastern",
+        position_code="LW",
+        position="Left Wing",
+        position_type="Forward",
+    )
+    player2 = PlayerScore(
+        first_name="Sidney",
+        last_name="Crosby",
+        full_name="Sidney Crosby",
+        first_score=20,
+        last_score=25,
+        full_score=45,
+        team="PIT",
+        division="Metropolitan",
+        conference="Eastern",
+        position_code="C",
+        position="Center",
+        position_type="Forward",
+    )
+
+    team1 = TeamScore(
+        abbrev="WSH",
+        name="Capitals",
+        total=420,
+        players=[player1],
+        division="Metropolitan",
+        conference="Eastern",
+    )
+    team2 = TeamScore(
+        abbrev="PIT",
+        name="Penguins",
+        total=450,
+        players=[player2],
+        division="Metropolitan",
+        conference="Eastern",
+    )
+
+    return {"WSH": team1, "PIT": team2}
+
+
+@pytest.fixture
+def mock_division_standings() -> dict[str, DivisionStandings]:
+    """Create mock division standings."""
+    return {}
+
+
+@pytest.fixture
+def mock_conference_standings() -> dict[str, ConferenceStandings]:
+    """Create mock conference standings."""
+    return {}
+
+
+@pytest.fixture
+def mock_playoff_standings() -> dict[str, list[PlayoffTeam]]:
+    """Create mock playoff standings."""
+    return {}
+
+
+class TestRunAnalysisBasics:
+    """Test basic run_analysis() function behavior."""
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    @patch("nhl_scrabble.cli.ReportGenerator")
+    def test_run_analysis_basic_text_format(
+        self,
+        mock_report_gen: MagicMock,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+        mock_team_scores: dict[str, TeamScore],
+    ) -> None:
+        """Test run_analysis with text format (default)."""
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = [{"abbrev": "WSH"}, {"abbrev": "PIT"}]
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_scorer = MagicMock()
+        mock_container.return_value.create_scorer.return_value = mock_scorer
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = (
+            mock_team_scores,
+            [],  # all_players
+            [],  # failed_teams
+        )
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        mock_report_gen.return_value.get_report.return_value = "Test Report"
+
+        # Run analysis
+        result = run_analysis(mock_config, quiet=True)
+
+        # Verify
+        assert result == "Test Report"
+        mock_api_client.get_teams.assert_called_once()
+        mock_team_processor.process_all_teams.assert_called_once()
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    def test_run_analysis_clear_cache(
+        self,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis with clear_cache=True."""
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        # Run analysis with clear_cache
+        with patch("nhl_scrabble.cli.ReportGenerator") as mock_report_gen:
+            mock_report_gen.return_value.get_report.return_value = "Test"
+            run_analysis(mock_config, clear_cache=True, quiet=True)
+
+        # Verify cache was cleared
+        mock_api_client.clear_cache.assert_called_once()
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    def test_run_analysis_with_season(
+        self,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis with specific season."""
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        # Run analysis with specific season
+        with patch("nhl_scrabble.cli.ReportGenerator") as mock_report_gen:
+            mock_report_gen.return_value.get_report.return_value = "Test"
+            run_analysis(mock_config, season="20222023", quiet=True)
+
+        # Verify season was passed
+        mock_api_client.get_teams.assert_called_with(season="20222023")
+        mock_team_processor.process_all_teams.assert_called_with(season="20222023")
+
+
+class TestRunAnalysisOutputFormats:
+    """Test run_analysis() with different output formats."""
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    @patch("nhl_scrabble.formatters.get_formatter")  # Patch in formatters module
+    def test_run_analysis_json_format(
+        self,
+        mock_get_formatter: MagicMock,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis with JSON format."""
+        mock_config.output_format = "json"
+
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = '{"teams": []}'
+        mock_get_formatter.return_value = mock_formatter
+
+        # Run analysis
+        result = run_analysis(mock_config, quiet=True)
+
+        # Verify
+        assert result == '{"teams": []}'
+        mock_get_formatter.assert_called_once_with("json")
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    @patch("nhl_scrabble.cli.generate_excel_report")
+    def test_run_analysis_excel_format(
+        self,
+        mock_excel: MagicMock,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+        tmp_path: Path,
+    ) -> None:
+        """Test run_analysis with Excel format."""
+        mock_config.output_format = "excel"
+        output_path = tmp_path / "output.xlsx"
+
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        # Run analysis
+        result = run_analysis(mock_config, output_path=output_path, quiet=True)
+
+        # Verify
+        assert result is None
+        mock_excel.assert_called_once()
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    def test_run_analysis_excel_without_output_raises(
+        self,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis with Excel format without output path raises ValueError."""
+        mock_config.output_format = "excel"
+
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="Excel format requires output path"):
+            run_analysis(mock_config, quiet=True)
+
+
+class TestRunAnalysisWithFilters:
+    """Test run_analysis() with filters applied."""
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    @patch("nhl_scrabble.cli.ReportGenerator")
+    @patch("nhl_scrabble.filters.filter_teams")  # Patch in filters module
+    @patch("nhl_scrabble.filters.filter_players")
+    @patch("nhl_scrabble.filters.filter_division_standings")
+    @patch("nhl_scrabble.filters.filter_conference_standings")
+    @patch("nhl_scrabble.filters.filter_playoff_standings")
+    def test_run_analysis_with_filters(  # noqa: PLR0913  # Test function with many patches
+        self,
+        mock_filter_playoff: MagicMock,
+        mock_filter_conf: MagicMock,
+        mock_filter_div: MagicMock,
+        mock_filter_players: MagicMock,
+        mock_filter_teams: MagicMock,
+        mock_report_gen: MagicMock,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis with active filters."""
+        # Create active filter
+        filters = AnalysisFilters.from_options(conference="Eastern")
+
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+
+        # Configure filter mocks to return filtered data
+        mock_filter_teams.return_value = {}
+        mock_filter_players.return_value = []
+        mock_filter_div.return_value = {}
+        mock_filter_conf.return_value = {}
+        mock_filter_playoff.return_value = {}
+
+        mock_report_gen.return_value.get_report.return_value = "Filtered Report"
+
+        # Run analysis with filters
+        result = run_analysis(mock_config, filters=filters, quiet=True)
+
+        # Verify filters were applied
+        assert mock_filter_teams.called
+        assert mock_filter_players.called
+        assert mock_filter_div.called
+        assert mock_filter_conf.called
+        assert mock_filter_playoff.called
+        assert result == "Filtered Report"
+
+
+class TestGenerateExcelReport:
+    """Test generate_excel_report() helper function."""
+
+    @patch("nhl_scrabble.cli.ExcelExporter")
+    def test_generate_excel_report_basic(
+        self,
+        mock_exporter_class: MagicMock,
+        tmp_path: Path,
+        mock_team_scores: dict[str, TeamScore],
+    ) -> None:
+        """Test basic Excel report generation."""
+        output_path = tmp_path / "report.xlsx"
+
+        mock_exporter = MagicMock()
+        mock_exporter_class.return_value = mock_exporter
+
+        # Call function
+        generate_excel_report(
+            team_scores=mock_team_scores,
+            all_players=[],
+            division_standings={},
+            conference_standings={},
+            playoff_standings={},
+            output=output_path,
+        )
+
+        # Verify exporter was called
+        mock_exporter.export_full_report.assert_called_once()
+
+    @patch("nhl_scrabble.cli.ExcelExporter")
+    def test_generate_excel_report_import_error(
+        self,
+        mock_exporter_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test Excel report generation handles ImportError."""
+        mock_exporter_class.side_effect = ImportError("openpyxl not installed")
+
+        output_path = tmp_path / "report.xlsx"
+
+        # Should raise ClickException
+        import click
+
+        with pytest.raises(click.ClickException, match="openpyxl not installed"):
+            generate_excel_report(
+                team_scores={},
+                all_players=[],
+                division_standings={},
+                conference_standings={},
+                playoff_standings={},
+                output=output_path,
+            )
+
+
+class TestRunAnalysisProgressDisplay:
+    """Test run_analysis() progress display and logging."""
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    @patch("nhl_scrabble.cli.console")
+    @patch("nhl_scrabble.cli.ReportGenerator")
+    def test_run_analysis_quiet_mode_suppresses_output(
+        self,
+        mock_report_gen: MagicMock,
+        mock_console: MagicMock,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis in quiet mode suppresses console output."""
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+        mock_report_gen.return_value.get_report.return_value = "Test"
+
+        # Run analysis in quiet mode
+        run_analysis(mock_config, quiet=True)
+
+        # Verify progress manager was created with quiet mode
+        mock_progress.assert_called_once_with(enabled=False)
+
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.ProgressManager")
+    @patch("nhl_scrabble.cli.PlayoffCalculator")
+    @patch("nhl_scrabble.cli.console")
+    @patch("nhl_scrabble.cli.ReportGenerator")
+    def test_run_analysis_displays_failed_teams(
+        self,
+        mock_report_gen: MagicMock,
+        mock_console: MagicMock,
+        mock_playoff_calc: MagicMock,
+        mock_progress: MagicMock,
+        mock_container: MagicMock,
+        mock_config: Config,
+    ) -> None:
+        """Test run_analysis displays failed teams warning."""
+        # Setup mocks
+        mock_api_client = MagicMock()
+        mock_api_client.get_teams.return_value = []
+        mock_container.return_value.create_api_client.return_value.__enter__.return_value = (
+            mock_api_client
+        )
+        mock_container.return_value.create_api_client.return_value.__exit__.return_value = False
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = (
+            {},
+            [],
+            ["WSH", "PIT"],  # failed teams
+        )
+        mock_team_processor.calculate_division_standings.return_value = {}
+        mock_team_processor.calculate_conference_standings.return_value = {}
+        mock_container.return_value.create_team_processor.return_value = mock_team_processor
+
+        mock_container.return_value.create_scorer.return_value = MagicMock()
+        mock_playoff_calc.return_value.calculate_playoff_standings.return_value = {}
+        mock_report_gen.return_value.get_report.return_value = "Test"
+
+        # Run analysis (not quiet to see console output)
+        run_analysis(mock_config, quiet=False)
+
+        # Verify console.print was called with failed teams message
+        assert mock_console.print.called
+        # Find the call with failed teams
+        failed_teams_call_found = False
+        for call in mock_console.print.call_args_list:
+            if "WSH" in str(call) or "PIT" in str(call):
+                failed_teams_call_found = True
+                break
+        assert failed_teams_call_found, "Should display failed teams warning"

--- a/tests/unit/test_cli_search_serve.py
+++ b/tests/unit/test_cli_search_serve.py
@@ -1,0 +1,542 @@
+"""Comprehensive unit tests for CLI search and serve commands.
+
+This module tests the search and serve commands for player search functionality
+and web server startup.
+
+Target: Improve coverage of search (lines 1186-1291) and serve (lines 1293-1401)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+# CRITICAL: Import cli module directly to ensure coverage
+from nhl_scrabble.cli import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestSearchCommand:
+    """Test search command implementation."""
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_text")
+    def test_search_basic_execution(
+        self,
+        mock_gen_text: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test basic search command execution."""
+        # Setup config
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        # Setup container and components
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        # Setup search
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_text.return_value = "Search results"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_json")
+    def test_search_json_format(
+        self,
+        mock_gen_json: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search with JSON output format."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_json.return_value = '{"results": []}'
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--format", "json"])
+
+        assert result.exit_code == 0
+        assert mock_gen_json.called
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_text")
+    def test_search_with_query(
+        self,
+        mock_gen_text: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search with query string."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_text.return_value = "Search results"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "Ovechkin"])
+
+        assert result.exit_code == 0
+        # Verify search was called with query
+        mock_search.search.assert_called_once()
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_text")
+    def test_search_with_fuzzy_matching(
+        self,
+        mock_gen_text: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search with fuzzy matching enabled."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_text.return_value = "Search results"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--fuzzy", "Ovechkn"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_text")
+    def test_search_with_score_filters(
+        self,
+        mock_gen_text: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search with min/max score filters."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_text.return_value = "Search results"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--min-score", "50", "--max-score", "100"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_text")
+    def test_search_with_limit(
+        self,
+        mock_gen_text: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search with result limit."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        # Return many results to test limiting
+        many_results = [MagicMock() for _ in range(100)]
+        mock_team_processor.process_all_teams.return_value = ({}, many_results, [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = many_results
+        mock_search.get_stats.return_value = {"total": 100}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_text.return_value = "Search results"
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--limit", "10"])
+
+        assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    @patch("nhl_scrabble.cli.generate_search_text")
+    def test_search_with_output_file(
+        self,
+        mock_gen_text: MagicMock,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test search writing to output file."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        mock_gen_text.return_value = "Search results content"
+
+        output_file = tmp_path / "search_results.txt"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--output", str(output_file)])
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        assert "Search results content" in output_file.read_text()
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    def test_search_handles_api_error(
+        self,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search handles API errors gracefully."""
+        from nhl_scrabble.api.nhl_client import NHLApiError
+
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.side_effect = NHLApiError("API down")
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search"])
+
+        assert result.exit_code == 1
+        assert "error" in result.output.lower() or "api" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_search_config_validation_error(self, mock_config_class: MagicMock) -> None:
+        """Test search handles config validation errors."""
+        mock_config_class.from_env.side_effect = ValueError("Invalid config")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search"])
+
+        assert result.exit_code != 0
+        assert "configuration error" in result.output.lower()
+
+    @patch("nhl_scrabble.cli.Config")
+    @patch("nhl_scrabble.cli.DependencyContainer")
+    @patch("nhl_scrabble.cli.PlayerSearch")
+    def test_search_with_quiet_mode(
+        self,
+        mock_search_class: MagicMock,
+        mock_container_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test search in quiet mode."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_container = MagicMock()
+        mock_api_client = MagicMock()
+        mock_api_client.__enter__.return_value = mock_api_client
+        mock_api_client.__exit__.return_value = None
+        mock_container.create_api_client.return_value = mock_api_client
+        mock_container.create_scorer.return_value = MagicMock()
+        mock_team_processor = MagicMock()
+        mock_team_processor.process_all_teams.return_value = ({}, [], [])
+        mock_container.create_team_processor.return_value = mock_team_processor
+        mock_container_class.return_value = mock_container
+
+        mock_search = MagicMock()
+        mock_search.search.return_value = []
+        mock_search.get_stats.return_value = {"total": 0}
+        mock_search_class.return_value = mock_search
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--quiet"])
+
+        assert result.exit_code == 0
+
+
+class TestServeCommand:
+    """Test serve command implementation."""
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_serve_basic_execution(
+        self,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test basic serve command execution."""
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config.log_max_bytes = 10485760
+        mock_config.log_backup_count = 3
+        mock_config_class.from_env.return_value = mock_config
+
+        # Mock uvicorn module
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["serve"])
+
+            assert result.exit_code == 0
+            assert mock_uvicorn.run.called
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_serve_with_custom_host_port(
+        self,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test serve with custom host and port."""
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config.log_max_bytes = 10485760
+        mock_config.log_backup_count = 3
+        mock_config_class.from_env.return_value = mock_config
+
+        # Mock uvicorn module
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["serve", "--host", "0.0.0.0", "--port", "5000"],  # noqa: S104
+            )
+
+            assert result.exit_code == 0
+            # Verify uvicorn.run was called with correct host/port
+            call_kwargs = mock_uvicorn.run.call_args[1]
+            assert call_kwargs["host"] == "0.0.0.0"  # noqa: S104
+            assert call_kwargs["port"] == 5000
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_serve_with_reload(
+        self,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test serve with reload flag."""
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config.log_max_bytes = 10485760
+        mock_config.log_backup_count = 3
+        mock_config_class.from_env.return_value = mock_config
+
+        # Mock uvicorn module
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["serve", "--reload"])
+
+            assert result.exit_code == 0
+            # Verify reload was enabled and import string was passed
+            call_args = mock_uvicorn.run.call_args
+            # First argument should be string when reload=True
+            assert isinstance(call_args[0][0], str)
+            assert call_args[1]["reload"] is True
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_serve_with_log_file(
+        self,
+        mock_config_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test serve with log file option."""
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config.log_max_bytes = 10485760
+        mock_config.log_backup_count = 3
+        mock_config_class.from_env.return_value = mock_config
+
+        # Mock uvicorn module
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            log_file = tmp_path / "server.log"
+            runner = CliRunner()
+            result = runner.invoke(cli, ["serve", "--log-file", str(log_file)])
+
+            assert result.exit_code == 0
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_serve_with_verbose(
+        self,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test serve with verbose logging."""
+        mock_config = MagicMock()
+        mock_config.sanitize_logs = False
+        mock_config.log_max_bytes = 10485760
+        mock_config.log_backup_count = 3
+        mock_config_class.from_env.return_value = mock_config
+
+        # Mock uvicorn module
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["serve", "--verbose"])
+
+            assert result.exit_code == 0
+
+    def test_serve_missing_uvicorn(self) -> None:
+        """Test serve fails gracefully when uvicorn not installed."""
+        with patch.dict("sys.modules", {"uvicorn": None}):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["serve"])
+
+            # Should abort when uvicorn not available
+            assert result.exit_code != 0
+
+    @patch("nhl_scrabble.cli.Config")
+    def test_serve_config_validation_error(self, mock_config_class: MagicMock) -> None:
+        """Test serve handles config validation errors."""
+        mock_config_class.from_env.side_effect = ValueError("Invalid config")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["serve"])
+
+        assert result.exit_code != 0
+        assert "configuration error" in result.output.lower()
+
+    def test_serve_invalid_port(self) -> None:
+        """Test serve with invalid port number."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["serve", "--port", "99999"])
+
+        # Click should validate port range
+        assert result.exit_code != 0

--- a/tests/unit/test_cli_test_analytics.py
+++ b/tests/unit/test_cli_test_analytics.py
@@ -1,0 +1,474 @@
+"""Comprehensive unit tests for CLI test-analytics command.
+
+This module tests the test-analytics command for fetching and analyzing
+test coverage data from Codecov API.
+
+Target: Improve coverage of test-analytics command (lines 1920-2001)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+# CRITICAL: Import cli module directly to ensure coverage
+from nhl_scrabble.cli import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestAnalyticsCommandBasics:
+    """Test basic test-analytics command functionality."""
+
+    def test_test_analytics_missing_token(self) -> None:
+        """Test test-analytics fails without CODECOV_TOKEN."""
+        runner = CliRunner()
+
+        with patch("nhl_scrabble.analytics.codecov_client.CodecovConfig") as mock_config_class:
+            mock_config = MagicMock()
+            mock_config.token = None
+            mock_config_class.from_env.return_value = mock_config
+
+            result = runner.invoke(cli, ["test-analytics"])
+
+            assert result.exit_code == 1
+            assert "CODECOV_TOKEN" in result.output
+            assert "not set" in result.output.lower()
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_default_all_sections(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics shows all sections by default."""
+        # Setup config
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        # Setup client
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = [{"commit": "abc", "coverage": 90}]
+        mock_client_class.return_value = mock_client
+
+        # Setup analyzer
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.return_value = []
+        mock_analyzer.analyze_test_performance.return_value = []
+        mock_analyzer.get_coverage_trend.return_value = {"trend": "up"}
+        mock_analyzer_class.return_value = mock_analyzer
+
+        # Setup formatter
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Test analytics report"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics"])
+
+        assert result.exit_code == 0
+        assert "Test analytics report" in result.output
+        # Verify all analyses were called (default shows all)
+        assert mock_analyzer.find_coverage_gaps.called
+        assert mock_analyzer.analyze_test_performance.called
+        assert mock_analyzer.get_coverage_trend.called
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_show_gaps_only(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with --show-gaps flag."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.return_value = [
+            {"file": "test.py", "coverage": 50, "target": 90},
+        ]
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Coverage gaps report"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--show-gaps"])
+
+        assert result.exit_code == 0
+        assert mock_analyzer.find_coverage_gaps.called
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_show_slow_tests(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with --show-slow-tests flag."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_perf = MagicMock()
+        mock_perf.test_name = "slow_test"
+        mock_perf.duration = 10.5
+        mock_analyzer.analyze_test_performance.return_value = [mock_perf]
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Slow tests report"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--show-slow-tests"])
+
+        assert result.exit_code == 0
+        assert mock_analyzer.analyze_test_performance.called
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_show_flaky_tests(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with --show-flaky-tests flag."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_perf = MagicMock()
+        mock_perf.test_name = "flaky_test"
+        mock_perf.flakiness_score = 0.5
+        mock_analyzer.analyze_test_performance.return_value = [mock_perf]
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Flaky tests report"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--show-flaky-tests"])
+
+        assert result.exit_code == 0
+        assert mock_analyzer.analyze_test_performance.called
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_show_trends(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with --show-trends flag."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = [{"commit": "abc", "coverage": 91}]
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.get_coverage_trend.return_value = {"trend": "improving"}
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Coverage trends report"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--show-trends"])
+
+        assert result.exit_code == 0
+        assert mock_analyzer.get_coverage_trend.called
+
+
+class TestAnalyticsCommandOutputFormats:
+    """Test test-analytics output format options."""
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.JSONFormatter")
+    def test_test_analytics_json_format(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with JSON output format."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.return_value = []
+        mock_analyzer.analyze_test_performance.return_value = []
+        mock_analyzer.get_coverage_trend.return_value = {}
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = '{"result": "json"}'
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--format", "json"])
+
+        assert result.exit_code == 0
+        assert mock_formatter_class.called
+        assert mock_formatter.format.called
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.HTMLFormatter")
+    def test_test_analytics_html_format(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with HTML output format."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.return_value = []
+        mock_analyzer.analyze_test_performance.return_value = []
+        mock_analyzer.get_coverage_trend.return_value = {}
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "<html>report</html>"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--format", "html"])
+
+        assert result.exit_code == 0
+        assert mock_formatter_class.called
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_with_output_file(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test test-analytics writes to output file."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.return_value = []
+        mock_analyzer.analyze_test_performance.return_value = []
+        mock_analyzer.get_coverage_trend.return_value = {}
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Analytics report content"
+        mock_formatter_class.return_value = mock_formatter
+
+        output_file = tmp_path / "analytics.txt"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--output", str(output_file)])
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        assert "Analytics report content" in output_file.read_text()
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    @patch("nhl_scrabble.analytics.formatters.TextFormatter")
+    def test_test_analytics_with_custom_target_coverage(
+        self,
+        mock_formatter_class: MagicMock,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics with custom target coverage."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.return_value = []
+        mock_analyzer.analyze_test_performance.return_value = []
+        mock_analyzer.get_coverage_trend.return_value = {}
+        mock_analyzer_class.return_value = mock_analyzer
+
+        mock_formatter = MagicMock()
+        mock_formatter.format.return_value = "Report"
+        mock_formatter_class.return_value = mock_formatter
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics", "--target-coverage", "95"])
+
+        assert result.exit_code == 0
+        # Verify target coverage was passed to find_coverage_gaps
+        mock_analyzer.find_coverage_gaps.assert_called_with(95.0)
+
+
+class TestAnalyticsCommandErrorHandling:
+    """Test test-analytics error handling."""
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    def test_test_analytics_api_error(
+        self,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics handles API errors gracefully."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.side_effect = Exception("API unavailable")
+        mock_client_class.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output or "error" in result.output.lower()
+
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovConfig")
+    @patch("nhl_scrabble.analytics.codecov_client.CodecovClient")
+    @patch("nhl_scrabble.analytics.analyzer.TestAnalyzer")
+    def test_test_analytics_analyzer_error(
+        self,
+        mock_analyzer_class: MagicMock,
+        mock_client_class: MagicMock,
+        mock_config_class: MagicMock,
+    ) -> None:
+        """Test test-analytics handles analyzer errors gracefully."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.token = "test-token"  # noqa: S105
+        mock_config_class.from_env.return_value = mock_config
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.get_test_analytics.return_value = {"tests": []}
+        mock_client.get_coverage_report.return_value = {"coverage": 90}
+        mock_client.get_coverage_trends.return_value = []
+        mock_client_class.return_value = mock_client
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.find_coverage_gaps.side_effect = Exception("Analysis failed")
+        mock_analyzer_class.return_value = mock_analyzer
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-analytics"])
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Task

**Task File**: `tasks/testing/040-expand-test-coverage-cli-module.md`
**GitHub Issue**: Closes #593

## Summary

Comprehensive test suite expansion for the CLI module, increasing coverage from 24.08% to 77.41% with 92 new tests across 3 test files. All 252 CLI tests now pass.

## New Test Files

### tests/unit/test_cli_core.py (29 tests)
- CLI initialization and command registration
- Output path validation (`validate_output_path`, `validate_cli_arguments`)
- Error messages and user-friendly output
- Edge cases and error handling

### tests/unit/test_cli_run_analysis.py (11 tests)  
- `run_analysis()` function workflow testing
- Output formats: text, JSON, Excel, CSV
- Filters: conference, division, teams
- Cache control and progress display
- Error handling and validation

### tests/unit/test_cli_analyze_command.py (52 tests)
- Analyze command options and validation
- Scoring systems: scrabble, wordle, uniform, custom config
- Filters: divisions, conferences, teams, positions, countries, scores
- Output handling (file paths, formats)
- Error paths and invalid inputs

## Coverage Progress

| Phase | Status | Description |
|-------|--------|-------------|
| Phase 0 | ✅ Complete | Investigation - actual coverage 24%, not 0% |
| Phase 1 | ✅ Complete | CLI core (initialization, validation) |
| Phase 2 | ✅ Complete | run_analysis() function |
| Phase 3 | ✅ Complete | Analyze command (options, validation) |
| Phase 4 | ⏳ Remaining | Error handling, signal handling |
| Phase 5 | ⏳ Remaining | Integration test enhancements |
| Phase 6 | ⏳ Remaining | Final documentation |

**Coverage**: 24.08% → 77.41% (+53.33 percentage points)
**Tests**: 252 total, all passing
**Target**: 95% (remaining work documented in task file)

## Remaining for 95% Target

- test-analytics command (lines 1920-2001, ~80 lines)
- Signal handling (lines 1738-1832, platform-specific, complex)
- Error path edge cases
- Integration test enhancements

## Testing

```bash
# Run new CLI tests
pytest tests/unit/test_cli*.py tests/integration/test_cli*.py -v

# Check coverage
pytest tests/unit/test_cli*.py tests/integration/test_cli*.py --cov=src/nhl_scrabble/cli --cov-report=term-missing

# Coverage: 77.41% (252 tests passing)
```

## Notes

- Task estimated at 24-32 hours
- Phases 0-3 complete (~40% of estimated effort)
- Significant progress made on core CLI functionality
- Remaining work focuses on specialized commands and platform-specific features
- All pre-commit hooks pass
- All tests pass on Python 3.12-3.14