### PR TITLE
test(coverage): increase test coverage for web/routes/players from 70.53% to 98.95%

### DIFF
--- a/tests/unit/web/test_player_detail_routes.py
+++ b/tests/unit/web/test_player_detail_routes.py
@@ -1,4 +1,8 @@
-"""Tests for player detail page routes."""
+"""Tests for player-related routes.
+
+This module tests error handling and edge cases for player routes that are not covered by
+integration tests.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -361,3 +365,163 @@ def test_player_detail_page_no_country_flag(
 
     # Should return 200 but no flag URL
     assert response.status_code == 200
+
+
+class TestPlayersPage:
+    """Tests for /players route."""
+
+    @patch("nhl_scrabble.web.routes.players.analyze_post", new_callable=AsyncMock)
+    def test_players_page_loads(
+        self,
+        mock_analyze: AsyncMock,
+        test_client: TestClient,
+        mock_analysis_data: dict,
+    ) -> None:
+        """Test that players page loads successfully.
+
+        Args:
+            mock_analyze: Mock analysis endpoint
+            test_client: Test client fixture
+            mock_analysis_data: Mock analysis data
+        """
+        # Setup mock
+        mock_analyze.return_value = mock_analysis_data
+
+        # Make request
+        response = test_client.get("/players")
+
+        # Assertions
+        assert response.status_code == 200
+        assert b"Connor McDavid" in response.content
+
+    def test_players_page_templates_not_configured(
+        self,
+        test_client: TestClient,
+    ) -> None:
+        """Test error handling when templates are not configured.
+
+        Args:
+            test_client: Test client fixture
+        """
+        # Temporarily remove templates from app state
+        original_templates = app.state.templates
+        app.state.templates = None
+
+        try:
+            response = test_client.get("/players")
+            assert response.status_code == 500
+            assert b"Templates not configured" in response.content
+        finally:
+            # Restore templates
+            app.state.templates = original_templates
+
+    @patch("nhl_scrabble.web.routes.players.analyze_post", new_callable=AsyncMock)
+    def test_players_page_nhl_api_error(
+        self,
+        mock_analyze: AsyncMock,
+        test_client: TestClient,
+    ) -> None:
+        """Test error handling when NHL API fails.
+
+        Args:
+            mock_analyze: Mock analysis endpoint
+            test_client: Test client fixture
+        """
+        from nhl_scrabble.api import NHLApiError
+
+        mock_analyze.side_effect = NHLApiError("API failed")
+
+        response = test_client.get("/players")
+
+        assert response.status_code == 500
+        assert b"Failed to fetch NHL data" in response.content
+
+
+class TestPlayerDetailPageEdgeCases:
+    """Additional edge case tests for player detail page."""
+
+    def test_player_detail_page_templates_not_configured(
+        self,
+        test_client: TestClient,
+    ) -> None:
+        """Test error handling when templates are not configured.
+
+        Args:
+            test_client: Test client fixture
+        """
+        # Temporarily remove templates from app state
+        original_templates = app.state.templates
+        app.state.templates = None
+
+        try:
+            response = test_client.get("/players/8478402")
+            assert response.status_code == 500
+            assert b"Templates not configured" in response.content
+        finally:
+            # Restore templates
+            app.state.templates = original_templates
+
+    @patch("nhl_scrabble.web.routes.players.analyze_post", new_callable=AsyncMock)
+    @patch("nhl_scrabble.web.routes.players.NHLApiClient")
+    def test_player_detail_page_with_team_standings(
+        self,
+        mock_nhl_client: MagicMock,
+        mock_analyze: AsyncMock,
+        test_client: TestClient,
+        mock_analysis_data: dict,
+        mock_nhl_player_details: dict,
+    ) -> None:
+        """Test that team name is looked up from team_standings when available.
+
+        Args:
+            mock_nhl_client: Mock NHL API client
+            mock_analyze: Mock analysis endpoint
+            test_client: Test client fixture
+            mock_analysis_data: Mock analysis data
+            mock_nhl_player_details: Mock NHL player details
+        """
+        # Add team_standings to mock data
+        mock_data_with_standings = {
+            **mock_analysis_data,
+            "team_standings": [
+                {
+                    "abbrev": "EDM",
+                    "name": "Edmonton Oilers",
+                    "division": "Pacific",
+                    "conference": "Western",
+                },
+            ],
+        }
+
+        # Setup mocks
+        mock_analyze.return_value = mock_data_with_standings
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_player_details.return_value = mock_nhl_player_details
+        mock_nhl_client.return_value.__enter__.return_value = mock_client_instance
+        mock_nhl_client.return_value.__exit__.return_value = None
+
+        # Make request
+        response = test_client.get("/players/8478402")
+
+        # Should return 200 and use full team name from standings
+        assert response.status_code == 200
+        assert b"Edmonton Oilers" in response.content
+
+
+class TestPlayerApiEndpoint:
+    """Tests for /api/players/{player_id} endpoint."""
+
+    def test_get_player_api_endpoint(
+        self,
+        test_client: TestClient,
+    ) -> None:
+        """Test that API endpoint returns 404 (not yet implemented).
+
+        Args:
+            test_client: Test client fixture
+        """
+        response = test_client.get("/api/players/8478402")
+
+        # This endpoint is not yet fully implemented
+        assert response.status_code == 404
+        assert b"Player 8478402 not found" in response.content


### PR DESCRIPTION
## Summary
- Increase test coverage for `src/nhl_scrabble/web/routes/players.py` from **70.53% to 98.95%**
- Add comprehensive tests for previously untested code paths
- All 15 tests pass successfully

## Changes
- ✅ Add tests for `players_page` function (`/players` route)
  - Test successful page load
  - Test templates not configured error
  - Test NHL API error handling
- ✅ Add test for templates not configured in `player_detail_page`
- ✅ Add test for team name lookup from `team_standings`
- ✅ Add test for `/api/players/{player_id}` endpoint
- ✅ Improve module docstring to clarify focus on error handling and edge cases

## Coverage Impact
**Before:** 70.53% (22 lines missing)
**After:** 98.95% (0 lines missing, 1 minor branch partial)

## Test Plan
- [x] All new tests pass locally
- [x] Coverage verified with pytest-cov
- [x] Pre-commit hooks pass
- [x] No regressions in existing tests