### PR TITLE
test(coverage): increase test coverage for analytics formatters from 81-84% to 97-100%

### DIFF
--- a/tests/unit/test_csv_formatter.py
+++ b/tests/unit/test_csv_formatter.py
@@ -77,6 +77,23 @@ class TestCSVFormatter:
         assert "test_api_fetch" in lines[1]
         assert "2.45" in lines[1]
 
+    def test_format_flaky_tests(
+        self,
+        formatter: CSVFormatter,
+        sample_tests: list[TestPerformance],
+    ) -> None:
+        """Test CSV formatting of flaky tests."""
+        data = {"flaky_tests": sample_tests}
+        result = formatter.format(data)
+
+        lines = result.strip().split("\n")
+
+        # Check data
+        assert "flaky_tests" in lines[1]
+        assert "test_api_fetch" in lines[1]
+        assert "0.123" in lines[1]  # Flakiness score
+        assert "0.05" in lines[1]  # Failure rate
+
     def test_format_empty_data(
         self,
         formatter: CSVFormatter,

--- a/tests/unit/test_excel_formatter.py
+++ b/tests/unit/test_excel_formatter.py
@@ -113,6 +113,30 @@ class TestExcelFormatter:
         assert "Slow Tests" in wb.sheetnames
         assert "Flaky Tests" in wb.sheetnames
 
+    def test_format_coverage_history(
+        self,
+        formatter: ExcelFormatter,
+    ) -> None:
+        """Test Excel formatting of coverage history trends."""
+        data = {
+            "coverage_history": [
+                {"timestamp": "2026-05-01", "coverage": 90.0},
+                {"timestamp": "2026-04-01", "coverage": 85.0},
+            ],
+        }
+        result = formatter.format(data)
+
+        import openpyxl
+
+        wb = openpyxl.load_workbook(BytesIO(result))
+        assert "Coverage Trends" in wb.sheetnames
+
+        ws = wb["Coverage Trends"]
+        assert ws["A1"].value == "Timestamp"
+        assert ws["B1"].value == "Coverage"
+        assert ws["A2"].value == "2026-05-01"
+        assert ws["B2"].value == 90.0
+
     def test_format_empty_data(
         self,
         formatter: ExcelFormatter,

--- a/tests/unit/test_markdown_formatter.py
+++ b/tests/unit/test_markdown_formatter.py
@@ -70,6 +70,20 @@ class TestMarkdownFormatter:
         assert "test_api_fetch" in result
         assert "2.45s" in result
 
+    def test_format_flaky_tests(
+        self,
+        formatter: MarkdownFormatter,
+        sample_tests: list[TestPerformance],
+    ) -> None:
+        """Test markdown formatting of flaky tests."""
+        data = {"flaky_tests": sample_tests}
+        result = formatter.format(data)
+
+        assert "## Flaky Tests" in result
+        assert "test_api_fetch" in result
+        assert "0.123" in result  # Flakiness score
+        assert "5.0%" in result  # Failure rate
+
     def test_format_trends(
         self,
         formatter: MarkdownFormatter,

--- a/tests/unit/test_table_formatter.py
+++ b/tests/unit/test_table_formatter.py
@@ -77,6 +77,20 @@ class TestTableFormatter:
         assert "test_api_fetch" in result
         assert "2.45s" in result
 
+    def test_format_flaky_tests(
+        self,
+        formatter: TableFormatter,
+        sample_tests: list[TestPerformance],
+    ) -> None:
+        """Test table formatting of flaky tests."""
+        data = {"flaky_tests": sample_tests}
+        result = formatter.format(data)
+
+        assert "Flaky Tests" in result
+        assert "test_api_fetch" in result
+        assert "0.123" in result  # Flakiness score
+        assert "5.0%" in result  # Failure rate
+
     def test_format_empty_data(
         self,
         formatter: TableFormatter,


### PR DESCRIPTION
## Summary

Improved test coverage for analytics formatters by adding missing test cases for untested code branches:

### Coverage Improvements
- **table_formatter.py**: 81.48% → **100.00%** (+18.52%)
- **csv_formatter.py**: 83.33% → **100.00%** (+16.67%)
- **markdown_formatter.py**: 84.44% → **97.78%** (+13.34%)
- **excel_formatter.py**: 81.43% → **98.57%** (+17.14%)

### Changes Made
- Added `test_format_flaky_tests()` to table_formatter, csv_formatter, and markdown_formatter
- Added `test_format_coverage_history()` to excel_formatter
- All new tests properly validate behavior with appropriate assertions

### Impact
- Overall project coverage increased from **94.40%** to **94.80%** (+0.40%)
- 4 analytics formatters now have near-perfect coverage
- No source code changes - purely test additions

## Test Plan
- [x] All 2544 existing tests pass
- [x] 4 new test cases added and passing
- [x] Coverage verified with `pytest --cov`
- [x] Pre-commit hooks pass